### PR TITLE
Fix compilation against pybind11 >= 2.3

### DIFF
--- a/katsdpimager/optional.h
+++ b/katsdpimager/optional.h
@@ -22,46 +22,8 @@ namespace pybind11
 namespace detail
 {
 
-/* Based on pybind11's optional_caster for std::optional. It's supposed to be
- * possible to just derive from
- * pybind11::detail::optional_caster<boost::optional<T>>, but it doesn't
- * compile (https://github.com/pybind/pybind11/issues/847).
- */
 template<typename T>
-struct type_caster<boost::optional<T>>
-{
-private:
-    using value_conv = make_caster<T>;
-
-public:
-    PYBIND11_TYPE_CASTER(boost::optional<T>, _("Optional[") + value_conv::name() + _("]"));
-
-    static handle cast(const boost::optional<T> &src, return_value_policy policy, handle parent)
-    {
-        if (!src)
-            return none().inc_ref();
-        return value_conv::cast(*src, policy, parent);
-    }
-
-    bool load(handle src, bool convert)
-    {
-        if (!src)
-            return false;
-        else if (src.is_none())
-        {
-            value = boost::none;
-            return true;
-        }
-        else
-        {
-            value_conv inner_caster;
-            if (!inner_caster.load(src, convert))
-                return false;
-            value = cast_op<T>(inner_caster);
-            return true;
-        }
-    }
-};
+struct type_caster<boost::optional<T>> : optional_caster<boost::optional<T>> {};
 
 } // namespace detail
 } // namespace pybind11

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pandas                    # via katsdpsigproc
 pkgconfig==1.1.0
 progress==1.2
 py                        # via pytest
-pybind11==2.2.4
+pybind11==2.4.2
 pycuda
 pyephem                   # via katpoint
 pygelf                    # via katsdpservices


### PR DESCRIPTION
Due to an older pybind11 bug, I was using a modified copy of it's
optional_caster template, and it was out of sync with changes in more
recent versions of pybind11. Removing the workaround fixed things.