### PR TITLE
Add tools for building binary wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.lsm.html
 /build
 /dist
+/wheelhouse
+/pip-wheel-metadata
 /doc/_build
 /tests/report
 .coverage

--- a/LICENSE
+++ b/LICENSE
@@ -25,3 +25,7 @@ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Binary distributions of this package contain code from the Eigen project, which
+is distributed under the Mozilla Public License, version 2.0. The source code
+for Eigen can be downloaded from http://eigen.tuxfamily.org.

--- a/katsdpimager/preprocess.cpp
+++ b/katsdpimager/preprocess.cpp
@@ -6,6 +6,8 @@
  * Most of the functionality is documented in the wrappers in preprocess.py.
  */
 
+#define EIGEN_MPL2_ONLY 1    /* Avoid accidentally using non-MPL2 code */
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/eigen.h>

--- a/manylinux/Dockerfile
+++ b/manylinux/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/pypa/manylinux2010_x86_64
+
+# yum provides only an old version of Eigen3 (too old)
+RUN cd /tmp && \
+    curl https://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2 | tar -jx && \
+    cd eigen-eigen-323c052e1731 && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr && \
+    make install
+
+COPY . /tmp/katsdpimager
+RUN /tmp/katsdpimager/manylinux/generate_wheels.sh

--- a/manylinux/generate_wheels.sh
+++ b/manylinux/generate_wheels.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+cd /tmp/katsdpimager
+mkdir -p /output
+for d in /opt/python/cp{35,36,37}*; do
+    git clean -xdf
+    # We know the compiler supports C++17, and using it avoids the need for Boost
+    sed -i 's/-std=c++1y/-std=c++17/' setup.py
+    $d/bin/python ./setup.py bdist_wheel -d .
+    auditwheel repair --plat manylinux2010_x86_64 -w /output katsdpimager-*-`basename $d`-linux_*.whl
+done

--- a/mkwheels.sh
+++ b/mkwheels.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+sudo docker build --pull -t ska-sa/katsdpimager/manylinux -f manylinux/Dockerfile .
+mkdir -p wheelhouse
+sudo docker run --rm -v "$PWD/wheelhouse:/wheelhouse" ska-sa/katsdpimager/manylinux sh -c 'cp -v /output/*.whl /wheelhouse'
+sudo chown `id -u`:`id -g` wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "pkgconfig", "pybind11==2.4.2"]
+requires = ["setuptools", "wheel", "pkgconfig==1.5.1"]

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,35 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages, Extension
 import glob
+import os
+
+
+class MissingPkgconfig:
+    """Raise an exception only when trying to convert it to a string.
+
+    This allows commands like setup.py clean to work even when pkgconfig
+    is not present, but makes it fail when trying to build the extension.
+    """
+    def __str__(self):
+        raise RuntimeError(
+            'The pkgconfig module was not found. Try upgrading pip to the latest '
+            'version and using it to install.')
+
 
 try:
     import pkgconfig
     eigen3 = pkgconfig.parse('eigen3')
 except ImportError:
-    eigen3 = {'include_dirs': set()}
+    eigen3 = {'include_dirs': {MissingPkgconfig()}}
 
 tests_require = ['nose', 'scipy', 'fakeredis']
+
+root_dir = os.path.dirname(__file__)
+pybind11_dir = os.path.join(root_dir, '3rdparty', 'pybind11', 'include', 'pybind11')
+if not os.path.exists(pybind11_dir):
+    raise RuntimeError(
+        'pybind11 directory not found in source tree. If this is a git checkout, you '
+        'can probably fix it by running "git submodule update --init --recursive".')
 
 extensions = [
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 class MissingPkgconfig:
     """Raise an exception only when trying to convert it to a string.
 
-    This allows commands like setup.py clean to work even when pkgconfig
+    This allows commands like ``setup.py clean`` to work even when pkgconfig
     is not present, but makes it fail when trying to build the extension.
     """
     def __str__(self):


### PR DESCRIPTION
Additionally, some safety checks are added to setup.py to warn about
common errors, and pybind11 is removed from pyproject.toml (it was
accidentally added when creating pyproject.toml).