### PR TITLE
Faster handling of all-flagged channels

### DIFF
--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -338,6 +338,13 @@ def process_channel(dataset, args, start_channel,
     image_p = channel_p.image_p
     grid_p = channel_p.grid_p
     clean_p = channel_p.clean_p
+
+    # Check if there is anything to do
+    if not any(reader.len(rel_channel, w_slice)
+               for w_slice in range(reader.num_w_slices(rel_channel))):
+        logger.info('Skipping channel %d which has no data', channel)
+        return
+
     logger.info('Processing channel %d', channel)
     # Create data and operation instances
     if args.host:

--- a/katsdpimager/preprocess.cpp
+++ b/katsdpimager/preprocess.cpp
@@ -424,7 +424,9 @@ void visibility_collector<P>::add_impl2(
         for (std::size_t i = 0; i < N; i++)
         {
             if (baselines[i] < 0)
-                continue; // autocorrelation
+                continue;   // autocorrelation
+            if (weights.col(i).cwiseEqual(0.0f).all())
+                continue;   // zero weights on all polarisations
             if (buffer_size == buffer_capacity)
                 compress();
 


### PR DESCRIPTION
Zero-weight data is eliminated during preprocessing, and channels with
no visibilities left are skipped early.

Closes SPR1-233.