### PR TITLE
Fix generation of binary wheels

### DIFF
--- a/manylinux/generate_wheels.sh
+++ b/manylinux/generate_wheels.sh
@@ -7,6 +7,6 @@ for d in /opt/python/cp{35,36,37}*; do
     git clean -xdf
     # We know the compiler supports C++17, and using it avoids the need for Boost
     sed -i 's/-std=c++1y/-std=c++17/' setup.py
-    $d/bin/python ./setup.py bdist_wheel -d .
+    $d/bin/pip wheel --no-deps .
     auditwheel repair --plat manylinux2010_x86_64 -w /output katsdpimager-*-`basename $d`-linux_*.whl
 done


### PR DESCRIPTION
The previous change broke the generate_wheels script. We're depending on
PEP 517 build isolation, but that required `pip wheel` not `setup.py
bdist_wheel`.