### PR TITLE
Katversion tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@ katsdpimager/_preprocess.so
 build
 doc/_build
 tests/report
-Dockerfile

--- a/manylinux/generate_wheels.sh
+++ b/manylinux/generate_wheels.sh
@@ -6,7 +6,6 @@ mkdir -p /output
 for d in /opt/python/cp{35,36,37}*; do
     git clean -xdf
     # We know the compiler supports C++17, and using it avoids the need for Boost
-    sed -i 's/-std=c++1y/-std=c++17/' setup.py
-    $d/bin/pip wheel --no-deps .
+    KATSDPIMAGER_STD_CXX=c++17 $d/bin/pip wheel --no-deps .
     auditwheel repair --plat manylinux2010_x86_64 -w /output katsdpimager-*-`basename $d`-linux_*.whl
 done

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ extensions = [
         language='c++',
         include_dirs=['3rdparty/pybind11/include'] + list(eigen3.get('include_dirs', [])),
         depends=glob.glob('katsdpimager/*.h'),
-        extra_compile_args=['-std=c++1y', '-g0', '-fvisibility=hidden'],
+        extra_compile_args=['-std=' + os.environ.get('KATSDPIMAGER_STD_CXX', 'c++1y'),
+                            '-g0', '-fvisibility=hidden'],
         libraries=list(eigen3.get('libraries', []))
     )
 ]


### PR DESCRIPTION
Hopefully *this* PR will now make things ready for release. The wheel building process ended up dirtying the source tree, which made katversion use a dirty version number instead of the shiny tag.