### PR TITLE
Discard visibilities with zero weight on any polarisation.

### DIFF
--- a/katsdpimager/preprocess.cpp
+++ b/katsdpimager/preprocess.cpp
@@ -427,8 +427,15 @@ void visibility_collector<P>::add_impl2(
         {
             if (baselines[i] < 0)
                 continue;   // autocorrelation
-            if (weights.col(i).cwiseEqual(0.0f).all())
-                continue;   // zero weights on all polarisations
+            if (weights.col(i).cwiseEqual(0.0f).any())
+            {
+                /* Discard visibilities with zero weight on any polarisation.
+                 * Zero weights generally indicates flagging, and if any
+                 * polarisation if flagged then at least one of the inputs is
+                 * contaminated and so no Stokes parameters will be clean.
+                 */
+                continue;
+            }
             if (buffer_size == buffer_capacity)
                 compress();
 

--- a/katsdpimager/test/test_preprocess.py
+++ b/katsdpimager/test/test_preprocess.py
@@ -73,40 +73,46 @@ class BaseTestVisibilityCollector:
             [-3.4, 7.6, 2.5],
             [-5.2, -10.6, 7.2],
             [12.102, 2.299, 4.6],   # Should merge with the first visibility in first channel
+            [-1.0, 2.0, 3.0]
         ], dtype=np.float32) * units.m
         weights = np.array([
             [
-                [1.3, 0.6, 1.2, 0.0],
+                [1.3, 0.6, 1.2, 0.1],
                 [1.0, 1.0, 1.0, 1.0],
                 [0.5, 0.6, 0.7, 0.8],
                 [1.1, 1.2, 1.3, 1.4],
+                [1.0, 0.0, 1.0, 1.0]    # Has a zero weight, so should be skipped
             ], [
-                [0.0, 2.4, 1.2, 2.6],   # Second channel is double and reverse of first
+                [0.2, 2.4, 1.2, 2.6],   # Second channel is double and reverse of first
                 [2.0, 2.0, 2.0, 2.0],
                 [1.6, 1.4, 1.2, 1.0],
-                [2.8, 2.6, 2.4, 2.2]
+                [2.8, 2.6, 2.4, 2.2],
+                [2.0, 2.0, 0.0, 2.0]
             ]], dtype=np.float32)
         baselines = np.array([
             0,
             -1,    # Auto-correlation: should be removed
             1,
             0,
+            0
         ], dtype=np.int16)
         vis = np.array([
             [
                 [0.5 - 2.3j, 0.1 + 4.2j, 0.0 - 3j, 1.5 + 0j],
                 [0.5 - 2.3j, 0.1 + 4.2j, 0.0 - 3j, 1.5 + 0j],
                 [1.5 + 1.3j, 1.1 + 2.7j, 1.0 - 2j, 2.5 + 1j],
-                [1.2 + 3.4j, 5.6 + 7.8j, 9.0 + 1.2j, 3.4 + 5.6j]
+                [1.2 + 3.4j, 5.6 + 7.8j, 9.0 + 1.2j, 3.4 + 5.6j],
+                [10.0, 10.0, 10.0, 10.0]
             ], [
                 [3.0 + 0j, 0.0 - 6j, 0.2 + 8.4j, 1.0 - 4.6j],
                 [3.0 + 0j, 0.0 - 6j, 0.2 + 8.4j, 1.0 - 4.6j],
                 [3.0 + 2j, 2.0 - 4j, 2.2 + 5.4j, 3.0 + 2.6j],
-                [6.8 + 11.2j, 18.0 + 2.4j, 11.2 + 15.6j, 2.4 + 6.8j]
+                [6.8 + 11.2j, 18.0 + 2.4j, 11.2 + 15.6j, 2.4 + 6.8j],
+                [20.0, 20.0, 20.0, 20.0]
             ]], dtype=np.complex64)
         if use_feed_angles:
             # TODO: use non-trivial feed angles and matrices
-            feed_angle1 = feed_angle2 = np.zeros(4, np.float32)
+            feed_angle1 = feed_angle2 = np.zeros(5, np.float32)
             mueller_stokes = mueller_circular = np.matrix(np.identity(4, np.complex64))
         else:
             feed_angle1 = feed_angle2 = mueller_circular = None
@@ -119,15 +125,15 @@ class BaseTestVisibilityCollector:
             [np.rec.fromarrays([
                 [[96, 18], [-42, -85]],
                 [[6, 3], [3, 1]],
-                [[2.4, 1.8, 2.5, 1.4], [0.5, 0.6, 0.7, 0.8]],
-                [[1.97 + 0.75j, 6.78 + 11.88j, 11.7 - 2.04j, 4.76 + 7.84j],
+                [[2.4, 1.8, 2.5, 1.5], [0.5, 0.6, 0.7, 0.8]],
+                [[1.97 + 0.75j, 6.78 + 11.88j, 11.7 - 2.04j, 4.91 + 7.84j],
                  [0.75 + 0.65j, 0.66 + 1.62j, 0.7 - 1.4j, 2.0 + 0.8j]],
                 [64, 65]], dtype=collector.store_dtype)],
             [np.rec.fromarrays([
                 [[387, 73], [387, 73], [-167, -340]],
                 [[1, 4], [2, 4], [4, 6]],
-                [[0.0, 2.4, 1.2, 2.6], [2.8, 2.6, 2.4, 2.2], [1.6, 1.4, 1.2, 1.0]],
-                [[0.0 + 0.0j, 0.0 - 14.4j, 0.24 + 10.08j, 2.6 - 11.96j],
+                [[0.2, 2.4, 1.2, 2.6], [2.8, 2.6, 2.4, 2.2], [1.6, 1.4, 1.2, 1.0]],
+                [[0.6 + 0.0j, 0.0 - 14.4j, 0.24 + 10.08j, 2.6 - 11.96j],
                  [19.04 + 31.36j, 46.8 + 6.24j, 26.88 + 37.44j, 5.28 + 14.96j],
                  [4.8 + 3.2j, 2.8 - 5.6j, 2.64 + 6.48j, 3.0 + 2.6j]],
                 [64, 64, 65]], dtype=collector.store_dtype)]


### PR DESCRIPTION
Zero weights generally indicates flagging, and if any
polarisation if flagged then at least one of the inputs is
contaminated and so no Stokes parameters will be clean.

The unit test needed changing because one of the test visibilities had
a single zero weight. I changed that weight, and added a new visibility
that I expect to be skipped.

I cheated on the new expected values in the test: I updated them to
match the actual values coming out after I changed the zero weight.

See SPR1-374.