### PR TITLE
Fix more instances of JY/BEAM (all caps)

### DIFF
--- a/scripts/imager-mkat-pipeline.py
+++ b/scripts/imager-mkat-pipeline.py
@@ -57,7 +57,7 @@ class Writer(frontend.Writer):
         }
 
     def write_fits_image(self, name, description, dataset, image, image_parameters, channel,
-                         beam=None, bunit='JY/BEAM'):
+                         beam=None, bunit='Jy/beam'):
         if name != 'clean':
             return
         # Add a unique component to the directory name so that it will be

--- a/scripts/imager.py
+++ b/scripts/imager.py
@@ -19,7 +19,7 @@ class Writer(frontend.Writer):
         self.args = args
 
     def write_fits_image(self, name, description, dataset, image, image_parameters, channel,
-                         beam=None, bunit='JY/BEAM'):
+                         beam=None, bunit='Jy/beam'):
         if name == 'clean':
             filename = self.args.output_file
         else:


### PR DESCRIPTION
It is supposed to be "Jy/beam" in FITS. The core io function had been
fixed, but it was being overridden by the scripts.