### PR TITLE
Predict noise from weights

### DIFF
--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -391,8 +391,8 @@ class Writer:
         noise
           Estimated noise in the residual image, in Jy/beam
         weights_noise
-          Estimated noise computed from the visibility and image weights.
-          It's in Jy/beam assuming the visibility weights are in Jy^-2.
+          Estimated noise computed from the visibility and image weights,
+          in Jy/beam. It can be ``None`` if not available.
         normalized_noise
           Increase in noise due to use of non-natural weights (unitless)
         peak

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -83,10 +83,12 @@ def make_weights(queue, reader, rel_channel, imager, weight_type, vis_block):
                     bar.next(len(chunk.uv))
         else:
             bar.next(total)
-        normalized_noise = imager.finalize_weights()
+        noise, normalized_noise = imager.finalize_weights()
         queue.finish()
+    if noise is not None:
+        logger.info('Thermal RMS noise (from weights): %g', noise)
     logger.info('Normalized thermal RMS noise: %g', normalized_noise)
-    return normalized_noise
+    return noise, normalized_noise
 
 
 def make_dirty(queue, reader, rel_channel, name, field, imager, mid_w, vis_block, degrid,
@@ -386,6 +388,9 @@ class Writer:
 
         noise
           Estimated noise in the residual image, in Jy/beam
+        weights_noise
+          Estimated noise computed from the visibility and image weights.
+          It's in Jy/beam assuming the visibility weights are in Jy^-2.
         normalized_noise
           Increase in noise due to use of non-natural weights (unitless)
         peak
@@ -428,8 +433,8 @@ def process_channel(dataset, args, start_channel,
     imager.clear_model()
 
     # Compute imaging weights
-    normalized_noise = make_weights(queue, reader, rel_channel,
-                                    imager, weight_p.weight_type, args.vis_block)
+    weights_noise, normalized_noise = make_weights(queue, reader, rel_channel,
+                                                   imager, weight_p.weight_type, args.vis_block)
     writer.write_fits_image('weights', 'image weights',
                             dataset, imager.buffer('weights_grid'), image_p, channel, bunit=None)
 
@@ -559,7 +564,9 @@ def process_channel(dataset, args, start_channel,
                             channel, restoring_beam)
     peak = find_peak(model, pbeam, noise)
     writer.statistics(dataset, image_p, channel,
-                      peak=peak, noise=noise, normalized_noise=normalized_noise)
+                      peak=peak, noise=noise,
+                      weights_noise=weights_noise,
+                      normalized_noise=normalized_noise)
 
 
 def run(args, context, queue, dataset, writer):

--- a/katsdpimager/loader_core.py
+++ b/katsdpimager/loader_core.py
@@ -114,6 +114,16 @@ class LoaderBase:
         """
         raise NotImplementedError('Abstract base class')
 
+    def weight_scale(self):
+        """Get scale factor between weights and inverse square noise.
+
+        The return value is the RMS noise (in Jansky) on a single real
+        correlator channel for a visibility of unit weight, or ``None``
+        if it is not known. This has no direct effect on imaging, but if
+        available is used to report statistics.
+        """
+        return None
+
     def data_iter(self, start_channel, stop_channel, max_chunk_vis=None):
         """Return an iterator that yields the data in chunks. Each chunk is a
         dictionary containing numpy arrays with the following keys:

--- a/katsdpimager/loader_katdal.py
+++ b/katsdpimager/loader_katdal.py
@@ -224,6 +224,12 @@ class LoaderKatdal(loader_core.LoaderBase):
     def has_feed_angles(self):
         return True
 
+    def weight_scale(self):
+        # A katdal complex visibility with weight 1 has an expected squared
+        # magnitude of 1, so the real and imaginary parts each have variance
+        # 1/2.
+        return math.sqrt(0.5)
+
     def data_iter(self, start_channel, stop_channel, max_chunk_vis=None):
         self._file.select(reset='F')
         n_file_times, n_file_chans, n_file_cp = self._file.shape

--- a/katsdpimager/report.py
+++ b/katsdpimager/report.py
@@ -102,6 +102,8 @@ class TargetStats:
         self.peak: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
         # Noise per channel (NaN where missing)
         self.noise: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
+        # Estimate neight from weights (NaN where missing)
+        self.weights_noise: u.Quantity = [math.nan] * common.channels * (u.Jy / beam)
         # Increase in noise due to imaging weights
         self.normalized_noise = [math.nan] * common.channels
         self.plots: Dict[str, str] = {}     # Divs to insert for plots returned by make_plots
@@ -112,12 +114,12 @@ class TargetStats:
         )
         self.channel_range = bokeh.models.Range1d(0, self.common.channels - 1, bounds='auto')
         self.time_on_target = katsdpimager.metadata.time_on_target(dataset, target)
-        self.predicted_natural_noise: Optional[u.Quantity] = None
+        self.model_natural_noise: Optional[u.Quantity] = None
         if self.common.sefd is not None and len(self.common.antennas) > 1:
             n = len(self.common.antennas)
             # Correlator efficiency is already folded in to self.common.sefd
             denom = math.sqrt(2 * n * (n - 1) * self.time_on_target * self.common.channel_width)
-            self.predicted_natural_noise = self.common.sefd / denom / u.beam
+            self.model_natural_noise = self.common.sefd / denom / u.beam
 
         mask = katsdpimager.metadata.target_mask(dataset, target)
         self.timestamps = dataset.timestamps[mask]
@@ -154,12 +156,13 @@ class TargetStats:
         data = {
             'frequency': self.common.frequencies.to_value(FREQUENCY_PLOT_UNIT),
             'status': self.status,
+            'weights_noise': self.weights_noise.to_value(FLUX_PLOT_UNIT),
             'noise': self.noise.to_value(FLUX_PLOT_UNIT),
             'peak': self.peak.to_value(FLUX_PLOT_UNIT)
         }
-        if self.predicted_natural_noise is not None:
-            predicted_noise = self.predicted_natural_noise * self.normalized_noise
-            data['predicted_noise'] = predicted_noise.to_value(FLUX_PLOT_UNIT)
+        if self.model_natural_noise is not None:
+            model_noise = self.model_natural_noise * self.normalized_noise
+            data['model_noise'] = model_noise.to_value(FLUX_PLOT_UNIT)
         return bokeh.models.ColumnDataSource(data)
 
     def make_time_data_source(self) -> bokeh.models.ColumnDataSource:
@@ -211,12 +214,14 @@ class TargetStats:
                 ('Channel', '$index'),
                 ('Peak', f'@peak{{%.3f}}{FLUX_PLOT_UNIT}'),
                 ('Noise', f'@noise{{%.3f}}{FLUX_PLOT_UNIT}'),
-                ('Predicted noise', f'@predicted_noise{{%.3f}}{FLUX_PLOT_UNIT}')
+                ('Predicted noise (weights)', f'@weights_noise{{%.3f}}{FLUX_PLOT_UNIT}')
+                ('Predicted noise (model)', f'@model_noise{{%.3f}}{FLUX_PLOT_UNIT}')
             ],
             formatters={
                 '@peak': si_format,
                 '@noise': si_format,
-                '@predicted_noise': si_format
+                '@weights_noise': si_format,
+                '@model_noise': si_format
             }
         ))
         self._line_with_markers(
@@ -225,10 +230,13 @@ class TargetStats:
         self._line_with_markers(
             fig, x='frequency', y='noise', source=source, name='noise',
             line_color=PALETTE[1], legend_label='Noise')
-        if self.predicted_natural_noise is not None:
+        self._line_with_markers(
+            fig, x='frequency', y='noise', source=source, name='weights_noise',
+            line_color=PALETTE[2], legend_label='Predicted noise (weights)')
+        if self.model_natural_noise is not None:
             self._line_with_markers(
-                fig, x='frequency', y='predicted_noise', source=source, name='predicted_noise',
-                line_color=PALETTE[2], legend_label='Predicted noise')
+                fig, x='frequency', y='model_noise', source=source, name='model_noise',
+                line_color=PALETTE[3], legend_label='Predicted noise (model)')
         self._add_channel_range(fig)
         return fig
 
@@ -302,6 +310,8 @@ def get_stats(dataset: katdal.DataSet,
         stats_lookup[target_desc].peak[channel] = peak * (u.Jy / u.beam)
     for ((target_desc, channel), noise) in telstate.get('noise', {}).items():
         stats_lookup[target_desc].noise[channel] = noise * (u.Jy / u.beam)
+    for ((target_desc, channel), noise) in telstate.get('weights_noise', {}).items():
+        stats_lookup[target_desc].weights_noise[channel] = noise * (u.Jy / u.beam)
     for ((target_desc, channel), normalized_noise) in telstate.get('normalized_noise', {}).items():
         stats_lookup[target_desc].normalized_noise[channel] = normalized_noise
     return common, stats

--- a/katsdpimager/report.py
+++ b/katsdpimager/report.py
@@ -214,7 +214,7 @@ class TargetStats:
                 ('Channel', '$index'),
                 ('Peak', f'@peak{{%.3f}}{FLUX_PLOT_UNIT}'),
                 ('Noise', f'@noise{{%.3f}}{FLUX_PLOT_UNIT}'),
-                ('Predicted noise (weights)', f'@weights_noise{{%.3f}}{FLUX_PLOT_UNIT}')
+                ('Predicted noise (weights)', f'@weights_noise{{%.3f}}{FLUX_PLOT_UNIT}'),
                 ('Predicted noise (model)', f'@model_noise{{%.3f}}{FLUX_PLOT_UNIT}')
             ],
             formatters={

--- a/katsdpimager/report.py
+++ b/katsdpimager/report.py
@@ -103,7 +103,7 @@ class TargetStats:
         # Noise per channel (NaN where missing)
         self.noise: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
         # Estimate neight from weights (NaN where missing)
-        self.weights_noise: u.Quantity = [math.nan] * common.channels * (u.Jy / beam)
+        self.weights_noise: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
         # Increase in noise due to imaging weights
         self.normalized_noise = [math.nan] * common.channels
         self.plots: Dict[str, str] = {}     # Divs to insert for plots returned by make_plots

--- a/katsdpimager/report.py
+++ b/katsdpimager/report.py
@@ -102,7 +102,7 @@ class TargetStats:
         self.peak: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
         # Noise per channel (NaN where missing)
         self.noise: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
-        # Estimate neight from weights (NaN where missing)
+        # Estimate noise from weights (NaN where missing)
         self.weights_noise: u.Quantity = [math.nan] * common.channels * (u.Jy / u.beam)
         # Increase in noise due to imaging weights
         self.normalized_noise = [math.nan] * common.channels

--- a/katsdpimager/report.py
+++ b/katsdpimager/report.py
@@ -231,7 +231,7 @@ class TargetStats:
             fig, x='frequency', y='noise', source=source, name='noise',
             line_color=PALETTE[1], legend_label='Noise')
         self._line_with_markers(
-            fig, x='frequency', y='noise', source=source, name='weights_noise',
+            fig, x='frequency', y='weights_noise', source=source, name='weights_noise',
             line_color=PALETTE[2], legend_label='Predicted noise (weights)')
         if self.model_natural_noise is not None:
             self._line_with_markers(

--- a/katsdpimager/templates/report.html.j2
+++ b/katsdpimager/templates/report.html.j2
@@ -89,7 +89,13 @@
                 <dd>Root-mean-square noise estimated using the median absolute
                 value of the residual Stokes-I image prior to primary beam
                 correction.</dd>
-                <dt>Predicted noise</dt>
+                <dt>Predicted noise (weights)</dt>
+                <dd>Noise estimate computed from the visibility weights. It
+                accounts for flagging and actual receiver performance.
+                Differences between this and the image noise likely indicate
+                problems in the imaging process such as incomplete or
+                divergent cleaning.
+                <dt>Predicted noise (model)</dt>
                 <dd>Noise estimate computed using a model of system equivalent
                 flux density, channel bandwidth, time on target and imaging
                 weights. Flagging (whether for RFI or otherwise) is <em>not</em>

--- a/katsdpimager/test/test_weight.py
+++ b/katsdpimager/test/test_weight.py
@@ -77,6 +77,7 @@ class TestDensityWeights:
                 sum_w += w
                 sum_dw += d * w
                 sum_d2w += d**2 * w
+        self.rms = np.sqrt(sum_d2w) / sum_dw
         self.normalized_rms = np.sqrt(sum_d2w * sum_w) / sum_dw
 
     @device_test
@@ -92,9 +93,10 @@ class TestDensityWeights:
         accel.HostArray.padded_view(tmp_data).fill(3)
         tmp_data[:] = self.data
         fn.buffer('grid').set(command_queue, tmp_data)
-        normalized_rms = fn()
+        rms, normalized_rms = fn()
         actual = fn.buffer('grid').get(command_queue)
         np.testing.assert_allclose(self.expected, actual, 1e-5, 1e-5)
+        np.testing.assert_allclose(self.rms, rms, 1e-6)
         np.testing.assert_allclose(self.normalized_rms, normalized_rms, 1e-6)
 
 

--- a/katsdpimager/weight.py
+++ b/katsdpimager/weight.py
@@ -534,7 +534,7 @@ class Weights(accel.OperationSequence):
             rms, normalized_rms = None, 1.0
         if self._fill is not None:
             self._fill()
-        return normalized_rms
+        return rms, normalized_rms
 
 
 class WeightsHost:

--- a/katsdpimager/weight.py
+++ b/katsdpimager/weight.py
@@ -220,8 +220,9 @@ class DensityWeights(accel.Operation):
     is :math:`1 / (aW + b)`. This allows for natural, uniform or robust
     weights. If not altered, the default gives uniform weights.
 
-    It also computes and returns the normalized thermal RMS, as described in
-    equation 3.5 of [Bri95]_.
+    It also computes and returns the RMS and normalized thermal RMS, as
+    described in equations 3.3 and 3.5 of [Bri95]_ (assuming that
+    ΔS_uw = 1).
 
     .. rubric:: Slots
 
@@ -279,7 +280,8 @@ class DensityWeights(accel.Operation):
         if isinstance(sums, accel.SVMArray):
             self.command_queue.finish()
         sums.get(self.command_queue, self._sums_host)
-        return np.sqrt(self._sums_host[2] * self._sums_host[0]) / self._sums_host[1]
+        rms = np.sqrt(self._sums_host[2]) / self._sums_host[1]
+        return rms, rms * np.sqrt(self._sums_host[0])
 
     def parameters(self):
         return {
@@ -421,7 +423,8 @@ class Weights(accel.OperationSequence):
      1. If using :const:`WeightType.ROBUST` weighting, set :attr:`robustness`.
      2. Call :meth:`clear`.
      3. For each batch of weights, call :meth:`grid`.
-     4. Call :meth:`finalize`, which returns the normalized thermal RMS.
+     4. Call :meth:`finalize`, which returns the thermal RMS and normalized
+        thermal RMS.
 
     .. rubric:: Slots
 
@@ -526,9 +529,9 @@ class Weights(accel.OperationSequence):
             self._density_weights.a = S2
             self._density_weights.b = 1.0
         if self._density_weights is not None:
-            normalized_rms = self._density_weights()
+            rms, normalized_rms = self._density_weights()
         else:
-            normalized_rms = 1.0
+            rms, normalized_rms = None, 1.0
         if self._fill is not None:
             self._fill()
         return normalized_rms
@@ -570,6 +573,7 @@ class WeightsHost:
     def finalize(self):
         if self.weight_type == WeightType.NATURAL:
             self.weights_grid.fill(1)
+            rms = None
             normalized_rms = 1.0
         elif self.weight_type == WeightType.UNIFORM:
             sum_w = np.sum(self.weights_grid[0])
@@ -579,7 +583,8 @@ class WeightsHost:
             np.reciprocal(self.weights_grid, out=self.weights_grid)
             # d^2w == d, because d is 1/w
             sum_d2w = np.sum(self.weights_grid[0])
-            normalized_rms = np.sqrt(sum_d2w * sum_w) / sum_dw
+            rms = np.sqrt(sum_d2w) / sum_dw
+            normalized_rms = rms * np.sqrt(sum_w)
         elif self.weight_type == WeightType.ROBUST:
             sum_sq = np.dot(self.weights_grid[0].flat, self.weights_grid[0].flat)
             sum = np.sum(self.weights_grid[0])
@@ -592,7 +597,8 @@ class WeightsHost:
             sum_w = np.sum(old_weights0)
             sum_dw = np.sum(self.weights_grid[0] * old_weights0)
             sum_d2w = np.sum(self.weights_grid[0]**2 * old_weights0)
-            normalized_rms = np.sqrt(sum_d2w * sum_w) / sum_dw
+            rms = np.sqrt(sum_d2w) / sum_dw
+            normalized_rms = rms * np.sqrt(sum_w)
         else:
             raise ValueError('Unknown weight_type {}'.format(self.weight_type))
-        return normalized_rms
+        return rms, normalized_rms

--- a/scripts/imager-mkat-pipeline.py
+++ b/scripts/imager-mkat-pipeline.py
@@ -102,6 +102,8 @@ class Writer(frontend.Writer):
         if np.isfinite(peak):
             self.telstate.set_indexed('peak', sub_key, peak)
         self.telstate.set_indexed('noise', sub_key, kwargs['noise'])
+        if kwargs.get('weights_noise') is not None:
+            self.telstate.set_indexed('weights_noise', sub_key, kwargs['weights_noise'])
         self.telstate.set_indexed('normalized_noise', sub_key, kwargs['normalized_noise'])
 
 


### PR DESCRIPTION
Add an extra line to the imaging report plot that predicts noise from the visibility weights. I wasn't quite sure how to label this to avoid confusion with the other prediction, but eventually ended up with "Predicted noise (weights)" and "Predicted weights (model)".

Closes SPR1-528.