### PR TITLE
Plot UV coverage in the report

### DIFF
--- a/katsdpimager/templates/report.html.j2
+++ b/katsdpimager/templates/report.html.j2
@@ -107,6 +107,16 @@
         </div>
       </div>
       <div class="row">
+        <div class="col">
+          <div class="card">
+            <h5 class="card-header">UV Coverage</h5>
+            <div class="card-body">
+              {{ target.uv_coverage | safe }}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
         <div class="col-md-6">
           <div class="card">
             <h5 class="card-header">Elevation</h5>

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     ext_modules=extensions,
     python_requires='>=3.6',
     install_requires=[
-        'numpy>=1.10.0', 'scipy', 'katsdpsigproc', 'katpoint', 'astropy>=1.3', 'progress',
+        'numpy>=1.16.0', 'scipy', 'katsdpsigproc', 'katpoint', 'astropy>=1.3', 'progress',
         'pycuda', 'scikit-cuda', 'h5py', 'ansicolors'
     ],
     tests_require=tests_require,
@@ -78,7 +78,7 @@ setup(
         'ms': ['python-casacore'],
         'katdal': ['katdal'],
         'benchmark': ['katpoint'],
-        'pipeline': ['katsdpservices', 'matplotlib', 'jinja2>=2.11', 'bokeh>=2.0.0']
+        'pipeline': ['katsdpservices', 'matplotlib>=3.1', 'jinja2>=2.11', 'bokeh>=2.0.0']
     },
     use_katversion=True,
     classifiers=[


### PR DESCRIPTION
It's added as an embedded SVG generated by matplotlib, rather than a
Bokeh plot, because Bokeh doesn't currently support elliptic arcs
(although matplotlib fakes them with Bezier curves, so it's possible
that this could be ported to Bokeh).

There may be some numerical stability issues for targets *exactly* on
the equatorial plane of date, because in that case the ellipse degrades
to a line. Targets with DEC=0 should generally be okay though because
that's the J2000 equator, which is not the same thing.