### PR TITLE
Add command-line arguments as HISTORY to the FITS file

### DIFF
--- a/katsdpimager/arguments.py
+++ b/katsdpimager/arguments.py
@@ -1,0 +1,126 @@
+"""Utilities for processing and reconstructing command-line arguments."""
+
+import argparse
+from typing import List, Iterable, Set, Mapping, Callable, Any
+
+import astropy.units as u
+
+
+def parse_quantity(str_value):
+    """Parse a string into an astropy Quantity. Rather than trying to guess
+    where the split occurs, we try every position from the back until we
+    succeed."""
+    for i in range(len(str_value), 0, -1):
+        try:
+            value = float(str_value[:i])
+            unit = u.Unit(str_value[i:])
+            return u.Quantity(value, unit)
+        except ValueError:
+            pass
+    raise ValueError('Could not parse {} as a quantity'.format(str_value))
+
+
+class SmartNamespace(argparse.Namespace):
+    """Namespace that tracks whether arguments are default or not.
+
+    There are a few requirements for this to work:
+    - All arguments must have a default, even if it is ``None``. In other
+      words, do not set the default to ``argparse.SUPPRESS``.
+    - The default must have a meaningful equality comparison with the
+      argument type.
+    - It will break down if the default is a string but the argument type is
+      not a string (in this case, argparse first sets it to the string value,
+      then replaces it with the conversion of that string value).
+
+    Access to the information is provided by :func:`argument_changed` rather
+    than a methods to avoid potential conflicts with command-line option
+    names.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        self._is_changed: Set[str] = set()
+        super().__init__(**kwargs)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if not name.startswith('_') and name in self and getattr(self, name) != value:
+            self._is_changed.add(name)
+        super().__setattr__(name, value)
+
+
+def argument_changed(namespace: SmartNamespace, name: str) -> bool:
+    """True if the name has been set to more than one value.
+
+    This typically indicates that it was first set to a default, then set
+    to a different value on the command line.
+    """
+    return name in namespace._is_changed
+
+
+def _normalize_name(name: str) -> str:
+    return name.replace('_', '-')
+
+
+def _bool_handler(name: str, value: object) -> List[str]:
+    norm = _normalize_name(name)
+    return [f'--{norm}'] if value else [f'--no-{norm}']
+
+
+def _to_str_handler(name: str, value: object) -> List[str]:
+    norm = _normalize_name(name)
+    return [f'--{norm}={value}']
+
+
+DEFAULT_TYPE_HANDLERS = {
+    bool: _bool_handler,
+    str: _to_str_handler,
+    int: _to_str_handler,
+    float: _to_str_handler,
+    u.Quantity: _to_str_handler
+}
+
+
+def unparse_args(
+        args: SmartNamespace,
+        exclude: Iterable[str] = (),
+        *,
+        arg_handlers: Mapping[str, Callable[[str, Any], List[str]]] = {},
+        type_handlers: Mapping[type, Callable[[str, Any], List[str]]] = {}) -> List[str]:
+    """Reconstruct an equivalent command line from parsed arguments.
+
+    Parameters
+    ----------
+    args
+        Parsed arguments
+    exclude
+        Elements of `args` to skip. This should usually include at least the
+        positional arguments.
+    arg_handlers
+        Special-case handling for particular arguments, mapping the name in `args`
+        to a callable that takes the name and value and returns command-line
+        arguments.
+    type_handlers
+        Like `arg_handlers`, but based on the type of the value rather than the
+        destination name. There are standard type handlers for int, float, str,
+        :class:`~astropy.units.Quantity` and bool. This is only used if the name
+        is not in `arg_handlers`.
+
+    Raises
+    ------
+    TypeError
+        If an argument has no handler.
+    """
+    skip = set(exclude)
+    out: List[str] = []
+    type_handlers = {**DEFAULT_TYPE_HANDLERS, **type_handlers}
+    for name, value in vars(args).items():
+        if name not in skip and argument_changed(args, name):
+            try:
+                handler = arg_handlers[name]
+            except KeyError:
+                arg_type = type(value)
+                try:
+                    handler = type_handlers[arg_type]
+                except KeyError:
+                    raise TypeError(f'No handler for {name} (type {type})') from None
+            out.extend(handler(name, value))
+    return out

--- a/katsdpimager/arguments.py
+++ b/katsdpimager/arguments.py
@@ -6,20 +6,6 @@ from typing import List, Iterable, Set, Mapping, Callable, Any
 import astropy.units as u
 
 
-def parse_quantity(str_value):
-    """Parse a string into an astropy Quantity. Rather than trying to guess
-    where the split occurs, we try every position from the back until we
-    succeed."""
-    for i in range(len(str_value), 0, -1):
-        try:
-            value = float(str_value[:i])
-            unit = u.Unit(str_value[i:])
-            return u.Quantity(value, unit)
-        except ValueError:
-            pass
-    raise ValueError('Could not parse {} as a quantity'.format(str_value))
-
-
 class SmartNamespace(argparse.Namespace):
     """Namespace that tracks whether arguments are default or not.
 

--- a/katsdpimager/arguments.py
+++ b/katsdpimager/arguments.py
@@ -19,7 +19,7 @@ class SmartNamespace(argparse.Namespace):
       then replaces it with the conversion of that string value).
 
     Access to the information is provided by :func:`argument_changed` rather
-    than a methods to avoid potential conflicts with command-line option
+    than via methods to avoid potential conflicts with command-line option
     names.
     """
 

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -287,7 +287,7 @@ def add_options(parser):
                        help='Field of view to image, relative to main lobe of beam [%(default)s]')
     group.add_argument('--image-oversample', type=float, default=5,
                        help='Pixels per beam [%(default)s]')
-    group.add_argument('--pixel-size', type=arguments.parse_quantity,
+    group.add_argument('--pixel-size', type=units.Quantity,
                        help='Size of each image pixel [computed from array]')
     group.add_argument('--pixels', type=int,
                        help='Number of pixels in image [computed from array]')
@@ -312,10 +312,10 @@ def add_options(parser):
                        help='Oversampling factor for kernel generation [%(default)s]')
     group.add_argument('--w-slices', type=int,
                        help='Number of W slices [computed from --kernel-width]')
-    group.add_argument('--w-step', type=arguments.parse_quantity, default=units.Quantity(1.0),
+    group.add_argument('--w-step', type=units.Quantity, default=units.Quantity(1.0),
                        help='Separation between W planes, in subgrid cells or a distance '
                             '[%(default)s]')
-    group.add_argument('--max-w', type=arguments.parse_quantity,
+    group.add_argument('--max-w', type=units.Quantity,
                        help='Largest w, as either distance or wavelengths [longest baseline]')
     group.add_argument('--aa-width', type=float, default=7,
                        help='Support of anti-aliasing kernel [%(default)s]')

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -266,14 +266,14 @@ class ChannelParameters:
         log_parameters("CLEAN parameters" + suffix, self.clean_p)
 
 
-def prepend_dunder(value):
+def prepend_dashes(value):
     return '--' + value
 
 
 def add_options(parser):
     group = parser.add_argument_group('Input selection')
     group.add_argument('--input-option', '-i',
-                       type=prepend_dunder, action='append', default=[], metavar='KEY=VALUE',
+                       type=prepend_dashes, action='append', default=[], metavar='KEY=VALUE',
                        help='Backend-specific input parsing option')
     group.add_argument('--start-channel', '-c', type=int, default=0,
                        help='Index of first channel to process [%(default)s]')

--- a/katsdpimager/io.py
+++ b/katsdpimager/io.py
@@ -84,7 +84,7 @@ def _fits_polarizations(header, axis, polarizations):
 
 
 def write_fits_image(dataset, image, image_parameters, filename, channel,
-                     beam=None, bunit='Jy/beam'):
+                     beam=None, bunit='Jy/beam', extra_fits_headers=None):
     """Write an image to a FITS file.
 
     Parameters
@@ -105,6 +105,8 @@ def write_fits_image(dataset, image, image_parameters, filename, channel,
     bunit : str, optional
         Value for the ``BUNIT`` header in the file. It can be explicitly set
         to ``None`` to avoid writing this key.
+    extra_fits_headers : mapping, optional
+        Extra headers to add to the FITS headers present.
 
     Raises
     ------
@@ -165,6 +167,8 @@ def write_fits_image(dataset, image, image_parameters, filename, channel,
         header['DATAMAX'] = datamax
 
     header.update(dataset.extra_fits_headers())
+    if extra_fits_headers is not None:
+        header.update(extra_fits_headers)
 
     # l axis is reversed, because RA increases right-to-left.
     # Explicitly converting to big-endian has two advantages:

--- a/katsdpimager/loader_core.py
+++ b/katsdpimager/loader_core.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Base classes used by loader modules"""
+
+from abc import ABC, abstractmethod
+
 import numpy as np
 from astropy import units
 import astropy.io.fits
@@ -8,19 +11,27 @@ import astropy.io.fits
 from . import parameters, sky_model
 
 
-class LoaderBase:
+class LoaderBase(ABC):
     def __init__(self, filename, options):
         """Open the file"""
         self.filename = filename
 
+    @abstractmethod
+    def command_line_options(self):
+        """Return command-line options, in string form.
+
+        Turn the `options` passed to the constructor into a canonical string
+        form e.g. ``['-i', 'foo=bar', '-i', 'blah']``.
+        """
+
     @classmethod
+    @abstractmethod
     def match(cls, filename):
         """Return True if this loader can handle the file"""
-        raise NotImplementedError('Abstract base class')
 
+    @abstractmethod
     def antenna_diameters(self):
         """Effective diameters of the antennas."""
-        raise NotImplementedError('Abstract base class')
 
     def antenna_diameter(self):
         """Return the common diameter of all dishes.
@@ -36,6 +47,7 @@ class LoaderBase:
             raise ValueError('Diameters are not all equal')
         return D
 
+    @abstractmethod
     def antenna_positions(self):
         """Return the antenna positions. The coordinate system is arbitrary
         since it is used only to compute baseline lengths.
@@ -45,7 +57,6 @@ class LoaderBase:
         Quantity, shape (n, 3)
             XYZ coordinates for each antenna.
         """
-        raise NotImplementedError('Abstract base class')
 
     def longest_baseline(self):
         """Return the length of the longest baseline."""
@@ -62,10 +73,11 @@ class LoaderBase:
         return parameters.ArrayParameters(
             self.antenna_diameter(), self.longest_baseline())
 
+    @abstractmethod
     def num_channels(self):
         """Return total number of channels, which are assumed to be contiguous."""
-        raise NotImplementedError('Abstract base class')
 
+    @abstractmethod
     def frequency(self, channel):
         """Return frequency for a given channel.
 
@@ -75,16 +87,16 @@ class LoaderBase:
             Frequency, in appropriate reference frame for transforming UVW
             coordinates from distance to wavelength count.
         """
-        raise NotImplementedError('Abstract base class')
 
+    @abstractmethod
     def band(self):
         """Return name for the frequency band in use.
 
         This is used for looking up externally-defined beam models. If the
         band name is not known, return None.
         """
-        raise NotImplementedError('Abstract base class')
 
+    @abstractmethod
     def phase_centre(self):
         """Return direction corresponding to l=0, m=0.
 
@@ -95,8 +107,8 @@ class LoaderBase:
 
             TODO: use katpoint or astropy.coordinates quantity instead?
         """
-        raise NotImplementedError('Abstract base class')
 
+    @abstractmethod
     def polarizations(self):
         """Return polarizations stored in the data.
 
@@ -106,13 +118,10 @@ class LoaderBase:
             List of polarization constants from
             :py:mod:`katsdpsigproc.parameters`.
         """
-        raise NotImplementedError('Abstract base class')
 
+    @abstractmethod
     def has_feed_angles(self):
-        """Return whether the data iterator will return `feed_angle1` and
-        `feed_angle2`.
-        """
-        raise NotImplementedError('Abstract base class')
+        """Return whether the data iterator will return `feed_angle1` and `feed_angle2`."""
 
     def weight_scale(self):
         """Get scale factor between weights and inverse square noise.
@@ -124,6 +133,7 @@ class LoaderBase:
         """
         return None
 
+    @abstractmethod
     def data_iter(self, start_channel, stop_channel, max_chunk_vis=None):
         """Return an iterator that yields the data in chunks. Each chunk is a
         dictionary containing numpy arrays with the following keys:
@@ -176,7 +186,6 @@ class LoaderBase:
             may be exceeded if the natural unit of the storage format (e.g. row
             in a measurement set) exceeds this size.
         """
-        raise NotImplementedError('Abstract base class')
 
     def sky_model(self):
         """Get the stored sky model, if any.
@@ -211,9 +220,9 @@ class LoaderBase:
         return astropy.io.fits.Header()
 
     @property
+    @abstractmethod
     def raw_data(self):
         """Return a handle to the the underlying class-specific data set."""
-        raise NotImplementedError('Abstract base class')
 
     def close(self):
         """Close any open file handles. The object must not be used after this."""

--- a/katsdpimager/polarization.py
+++ b/katsdpimager/polarization.py
@@ -146,3 +146,7 @@ def parse_stokes(str_value):
         elif cnt > 0:
             ans.append(STOKES_NAMES.index(p))
     return sorted(ans)
+
+
+def unparse_stokes(params):
+    return ''.join(STOKES_NAMES[idx] for idx in params)

--- a/katsdpimager/test/test_arguments.py
+++ b/katsdpimager/test/test_arguments.py
@@ -2,6 +2,7 @@
 
 import argparse
 
+import astropy.units as u
 from nose.tools import assert_equal
 
 from .. import arguments
@@ -18,7 +19,7 @@ class TestUnparse:
         parser.add_argument('--str-default', type=str, default='')
         parser.add_argument('--positive', action='store_true')
         parser.add_argument('--no-negative', dest='negative', action='store_false')
-        parser.add_argument('--quantity', type=arguments.parse_quantity)
+        parser.add_argument('--quantity', type=u.Quantity)
         self.parser = parser
 
     def test_no_args(self):

--- a/katsdpimager/test/test_arguments.py
+++ b/katsdpimager/test/test_arguments.py
@@ -1,7 +1,6 @@
 """Tests for :mod:`katsdpimager.arguments`"""
 
 import argparse
-import decimal
 
 from nose.tools import assert_equal
 

--- a/katsdpimager/test/test_arguments.py
+++ b/katsdpimager/test/test_arguments.py
@@ -1,0 +1,76 @@
+"""Tests for :mod:`katsdpimager.arguments`"""
+
+import argparse
+import decimal
+
+from nose.tools import assert_equal
+
+from .. import arguments
+
+
+class TestUnparse:
+    def setUp(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--int', type=int)
+        parser.add_argument('--int-default', type=int, default=3)
+        parser.add_argument('--float', type=float)
+        parser.add_argument('--float-default', type=float, default=2.5)
+        parser.add_argument('--str', type=str)
+        parser.add_argument('--str-default', type=str, default='')
+        parser.add_argument('--positive', action='store_true')
+        parser.add_argument('--no-negative', dest='negative', action='store_false')
+        parser.add_argument('--quantity', type=arguments.parse_quantity)
+        self.parser = parser
+
+    def test_no_args(self):
+        """Pass no arguments."""
+        args = self.parser.parse_args([], namespace=arguments.SmartNamespace())
+        assert_equal(arguments.unparse_args(args), [])
+
+    def test_defaults(self):
+        """Pass arguments with default values."""
+        argv = ['--int-default=3', '--float-default=2.5', '--str-default=']
+        args = self.parser.parse_args(argv, namespace=arguments.SmartNamespace())
+        assert_equal(arguments.unparse_args(args), [])
+
+    def test_all_args(self):
+        """Pass all arguments."""
+        argv = [
+            '--int=1',
+            '--int-default=2',
+            '--float=3.1',
+            '--float-default=4.5',
+            '--str=hello',
+            '--str-default=world',
+            '--positive',
+            '--no-negative',
+            '--quantity=12.0 rad'
+        ]
+        args = self.parser.parse_args(argv, namespace=arguments.SmartNamespace())
+        assert_equal(arguments.unparse_args(args), argv)
+
+    def test_exclude(self):
+        """Test the exclude argument."""
+        self.parser.add_argument('positional', type=str)
+        argv = ['positional', '--int=1', '--int-default=2']
+        args = self.parser.parse_args(argv, namespace=arguments.SmartNamespace())
+        unparsed = arguments.unparse_args(args, exclude=['positional', 'int'])
+        assert_equal(unparsed, ['--int-default=2'])
+
+    def test_arg_handler(self):
+        """Test the `arg_handlers` option."""
+        self.parser.add_argument('positional', type=str)
+        argv = ['--int=1', 'positional_arg']
+        args = self.parser.parse_args(argv, namespace=arguments.SmartNamespace())
+        unparsed = arguments.unparse_args(
+            args, arg_handlers={'positional': lambda name, value: [value]})
+        assert_equal(unparsed, argv)
+
+    def test_type_handler(self):
+        """Test the type_handlers option."""
+        self.parser.add_argument('--list', type=str, action='append')
+        argv = ['--list=1', '--list=2']
+        args = self.parser.parse_args(argv, namespace=arguments.SmartNamespace())
+        unparsed = arguments.unparse_args(
+            args, type_handlers={list: lambda name, value: [f'--{name}={x}' for x in value]})
+        assert_equal(unparsed, argv)


### PR DESCRIPTION
This is made much more complicated by the need to remove
authentication-related information, which precludes just dumping
`sys.argv`. So instead functions are added to reconstruct an equivalent
command line from the parsed args.

Closes SPR1-498.