### PR TITLE
Unvendor pybind11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pybind11"]
-	path = 3rdparty/pybind11
-	url = https://github.com/pybind/pybind11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "pkgconfig==1.5.1", "katversion==0.9"]
+requires = ["setuptools", "wheel", "pkgconfig==1.5.1", "katversion==0.9", "pybind11==2.5.0"]

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ class Missing:
 
     def __str__(self):
         raise RuntimeError(
-            ('The {} module was not found. Try upgrading pip to the latest '
-             'version and using it to install.').format(self.name))
+            ("The {name} module was not found. You should use pip to install, "
+             "which will automatically install {name} in the build environment. "
+             "If you are using pip, check that you're using at least "
+             "version 19.0.").format(name=self.name))
 
 
 try:


### PR DESCRIPTION
Update pybind11 to 2.5.0 and load it via pyproject.toml rather than a
git submodule (2.5.0 finally plays nice with build isolation).