### PR TITLE
Add option to use RFI mask

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ katsdp.setDependencies([
     'ska-sa/katsdpdockerbase/master',
     'ska-sa/katpoint/master',
     'ska-sa/katdal/master',
-    'ska-sa/katsdpmodels/fetch_base',
+    'ska-sa/katsdpmodels/master',
     'ska-sa/katsdpsigproc/master',
     'ska-sa/katsdpservices/master',
     'ska-sa/katsdptelstate/master'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ katsdp.setDependencies([
     'ska-sa/katsdpdockerbase/master',
     'ska-sa/katpoint/master',
     'ska-sa/katdal/master',
+    'ska-sa/katsdpmodels/fetch_base',
     'ska-sa/katsdpsigproc/master',
     'ska-sa/katsdpservices/master',
     'ska-sa/katsdptelstate/master'])

--- a/doc/user.rst
+++ b/doc/user.rst
@@ -168,6 +168,14 @@ Input selection options
      comma-separated list or ``all`` (the default) to apply all available
      calibration solutions. Refer to the katdal documentation for more
      information.
+   rfi-mask=none | fixed | config
+     Skip imaging channels that are known *a priori* to be affected by RFI. The
+     default is ``none``. The other values require a sufficiently recent
+     observation, as well as internet access to retrieve the model. The value
+     ``fixed`` uses a mask that is fixed at the time the observation was made
+     and which will never change, while ``config`` uses a model that is
+     appropriate for the time of the observation but may be refined over
+     time.
 
    To provide multiple key-value pairs, specify :option:`-i` multiple times.
 

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -437,6 +437,9 @@ def process_channel(dataset, args, start_channel,
     clean_p = channel_p.clean_p
 
     # Check if there is anything to do
+    if not dataset.channel_enabled(channel_p.channel):
+        logger.info('Skipping channel %d which is masked', channel)
+        return
     if not any(reader.len(rel_channel, w_slice)
                for w_slice in range(reader.num_w_slices(rel_channel))):
         logger.info('Skipping channel %d which has no data', channel)

--- a/katsdpimager/loader_core.py
+++ b/katsdpimager/loader_core.py
@@ -133,6 +133,15 @@ class LoaderBase(ABC):
         """
         return None
 
+    def channel_enabled(self, channel):
+        """Whether the channel should be imaged.
+
+        This can be used to implement a loader-specific channel mask. For
+        efficiency, data for these channels should all be masked by
+        :meth:`data_iter`.
+        """
+        return True
+
     @abstractmethod
     def data_iter(self, start_channel, stop_channel, max_chunk_vis=None):
         """Return an iterator that yields the data in chunks. Each chunk is a

--- a/katsdpimager/loader_katdal.py
+++ b/katsdpimager/loader_katdal.py
@@ -258,6 +258,9 @@ class LoaderKatdal(loader_core.LoaderBase):
         # 1/2.
         return math.sqrt(0.5)
 
+    def channel_enabled(self, channel):
+        return not self._channel_mask[channel]
+
     def data_iter(self, start_channel, stop_channel, max_chunk_vis=None):
         self._file.select(reset='F')
         n_file_times, n_file_chans, n_file_cp = self._file.shape

--- a/katsdpimager/loader_katdal.py
+++ b/katsdpimager/loader_katdal.py
@@ -15,6 +15,8 @@ import urllib
 
 import katdal
 from katdal.lazy_indexer import DaskLazyIndexer
+import katsdpmodels.fetch.requests
+import katsdpmodels.rfi_mask
 import numpy as np
 from astropy import units
 from astropy.time import Time
@@ -107,6 +109,9 @@ class LoaderKatdal(loader_core.LoaderBase):
                             help='Override reference antenna for identifying scans [array]')
         parser.add_argument('--apply-cal', type=str, default='all',
                             help='Comma-separated calibration solutions to pre-apply [%(default)s]')
+        parser.add_argument('--rfi-mask', type=str, default='none',
+                            choices=('none', 'fixed', 'config'),
+                            help='Use RFI mask from the observation to skip channels')
         parser.add_argument('--access-key', type=str, help='S3 access key')
         parser.add_argument('--secret-key', type=str, help='S3 secret key')
         args = parser.parse_args(options, namespace=arguments.SmartNamespace())
@@ -177,6 +182,21 @@ class LoaderKatdal(loader_core.LoaderBase):
         if not corrections:
             corrections = 'none'
         _logger.info('Calibration corrections applied: %s', corrections)
+
+        # Determine RFI mask, if any (TODO: eventually katdal should do some of this)
+        if args.rfi_mask != 'none':
+            telstate = self._file.source.telstate
+            base_url = telstate['sdp_model_base_url']
+            rfi_mask_key = telstate.join('model', 'rfi_mask', args.rfi_mask)
+            rel_url = telstate[rfi_mask_key]
+            url = urllib.parse.urljoin(base_url, rel_url)
+            rfi_mask = katsdpmodels.fetch.requests.fetch_model(url, katsdpmodels.rfi_mask.RFIMask)
+            max_length = rfi_mask.max_baseline_length(self._file.channel_freqs * units.Hz)
+            self._channel_mask = max_length > 0
+        else:
+            self._channel_mask = None
+
+        # Record command-line options for FITS HISTORY
         unparsed = arguments.unparse_args(args, {'access_key', 'secret_key'})
         self._command_line_options = []
         for arg in unparsed:
@@ -288,6 +308,8 @@ class LoaderKatdal(loader_core.LoaderBase):
             # Flag missing correlation products
             if self._missing_corr_products:
                 flags[:, :, self._missing_corr_products] = True
+            if self._channel_mask is not None:
+                flags |= self._channel_mask[np.newaxis, start_channel : stop_channel, np.newaxis]
             # Apply flags to weights
             weights *= np.logical_not(flags)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ urllib3                   # via requests
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
 katsdpimageutils @ git+https://github.com/ska-sa/katsdpimageutils
-katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels@fetch_base
+katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels
 katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ decorator                 # via pycuda, katsdpsigproc
 docutils                  # via botocore
 ephem                     # via pyephem
 future                    # via katdal, katpoint
-h5py                      # via katdal
+h5py                      # via katdal, katsdpmodels
 idna                      # via requests
 jinja2==2.11.2            # katsdpdockerbase version is currently too old
 jmespath                  # via botocore
@@ -42,18 +42,20 @@ pytz                      # via pandas
 pyyaml                    # via bokeh
 rdbtools                  # via katsdptelstate
 redis                     # via katsdptelstate
-requests                  # via katdal
+requests                  # via katdal, katsdpmodels
 scikit-cuda
 scipy                     # via katdal (its fallback interpolation behaves differently)
+strict-rfc3339            # via katsdpmodels
 six                       # via pytools, python-dateutil, bokeh
 toolz                     # via dask[array]
 tornado                   # via bokeh
-typing_extensions         # via katsdpsigproc
+typing_extensions         # via katsdpsigproc, katsdpmodels
 urllib3                   # via requests
 
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
 katsdpimageutils @ git+https://github.com/ska-sa/katsdpimageutils
+katsdpmodels @ git+https://github.com/ska-sa/katsdpmodels@fetch_base
 katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'cpu': ['numba'],
         'report': ['aplpy', 'matplotlib', 'mako'],
         'ms': ['python-casacore'],
-        'katdal': ['katdal'],
+        'katdal': ['katdal', 'katsdpmodels[requests]'],
         'benchmark': ['katpoint'],
         'pipeline': ['katsdpservices', 'katsdpimageutils',
                      'matplotlib>=3.1', 'jinja2>=2.11', 'bokeh>=2.0.0']


### PR DESCRIPTION
When `-i rfi-mask=fixed` or `-i rfi-mask=config` is given, use the appropriate RFI mask for the telescope state.

It's not the most optimised implementation in terms of skipping work as early as possible. It's really aimed at the automated pipeline, which will itself skip launching imaging tasks if they contain no work.