### PR TITLE
Don't raise an exception if a Stopwatch is stopped twice

### DIFF
--- a/katsdpimager/profiling.py
+++ b/katsdpimager/profiling.py
@@ -182,7 +182,7 @@ class Stopwatch(contextlib.ContextDecorator):
 
     def stop(self) -> None:
         if self._start_time is None:
-            raise RuntimeError(f'Stopwatch {self._frame.name} is already stopped')
+            return
         self._nvtx_range.__exit__(None, None, None)
         stop_time = time.monotonic()
         record = Record(self._frame, self._start_time, stop_time)
@@ -199,8 +199,6 @@ class NullStopwatch(Stopwatch):
         self._start_time = 0.0   # Just for the error checking
 
     def stop(self) -> None:
-        if self._start_time is None:
-            raise RuntimeError(f'Stopwatch {self._frame.name} is already stopped')
         self._start_time = None
 
 


### PR DESCRIPTION
If an exception is thrown into a generator wrapped with
`@profile_generator` (in particular, if the generator is closed before
it finishes naturally), then the stopwatch will have been stopped inside
the context manager, and the context manager cleanup would try to stop
it again, raising an exception.

Instead, silently do nothing on a double stop.