### PR TITLE
Apply band mask in addition to RFI mask to skip channels

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -169,13 +169,13 @@ Input selection options
      calibration solutions. Refer to the katdal documentation for more
      information.
    rfi-mask=none | fixed | config
-     Skip imaging channels that are known *a priori* to be affected by RFI. The
-     default is ``none``. The other values require a sufficiently recent
-     observation, as well as internet access to retrieve the model. The value
-     ``fixed`` uses a mask that is fixed at the time the observation was made
-     and which will never change, while ``config`` uses a model that is
-     appropriate for the time of the observation but may be refined over
-     time.
+     Skip imaging channels that are known *a priori* to be affected by RFI or
+     weak bandpass response. The default is ``none``. The other values require
+     a sufficiently recent observation, as well as internet access to retrieve
+     the model. The value ``fixed`` uses a mask that is fixed at the time the
+     observation was made and which will never change, while ``config`` uses a
+     model that is appropriate for the time of the observation but may be
+     refined over time.
 
    To provide multiple key-value pairs, specify :option:`-i` multiple times.
 

--- a/katsdpimager/loader_katdal.py
+++ b/katsdpimager/loader_katdal.py
@@ -114,7 +114,7 @@ class LoaderKatdal(loader_core.LoaderBase):
                             help='Comma-separated calibration solutions to pre-apply [%(default)s]')
         parser.add_argument('--rfi-mask', type=str, default='none',
                             choices=('none', 'fixed', 'config'),
-                            help='Use RFI mask from the observation to skip channels')
+                            help='Use RFI and band mask from the observation to skip channels')
         parser.add_argument('--access-key', type=str, help='S3 access key')
         parser.add_argument('--secret-key', type=str, help='S3 secret key')
         args = parser.parse_args(options, namespace=arguments.SmartNamespace())


### PR DESCRIPTION
This makes little difference to performance at the moment, but makes the
channel status in the report more representative.