### PR TITLE
Fix stack traces when using profile_generator

### DIFF
--- a/katsdpimager/test/test_profiling.py
+++ b/katsdpimager/test/test_profiling.py
@@ -205,14 +205,19 @@ class TestProfiler:
         Profiler.set_profiler(self.profiler)
         result = []
         for item in slow_range(3):
-            monotonic.return_value += 2.0
-            result.append(item)
+            with profile('other_work'):
+                monotonic.return_value += 2.0
+                result.append(item)
 
         assert_equal(result, [0, 1, 2])
         frame = Frame('slow_range', {'reps': 3})
+        frame2 = Frame('other_work')
         assert_equal(self.profiler.records, [
             Record(frame, 0.0, 1.0),
+            Record(frame2, 1.0, 3.0),
             Record(frame, 3.0, 4.0),
+            Record(frame2, 4.0, 6.0),
             Record(frame, 6.0, 7.0),
+            Record(frame2, 7.0, 9.0),
             Record(frame, 9.0, 9.5)
         ])


### PR DESCRIPTION
When the generator yielded, the timer was stopped, but it would still
appear in the stack trace if other profiled functions were called while
the generator was alive. I think this could severely mess up flamegraphs
because time spent in children is subtracted from total time to get time
spent only in self.

To fix this, pushing and popping the frame is now handled by the
stopwatch class on each stop and start.