### PR TITLE
Do not use gzip compression in HDF5 temp file

### DIFF
--- a/katsdpimager/preprocess.py
+++ b/katsdpimager/preprocess.py
@@ -235,7 +235,6 @@ class VisibilityCollectorHDF5(VisibilityCollector):
             "vis", (self.num_channels, max_w_slices, 0),
             maxshape=(self.num_channels, max_w_slices, None),
             dtype=self.store_dtype,
-            compression='gzip',
             chunks=(1, 1, chunk_elements))
 
     def _emit(self, elements):


### PR DESCRIPTION
It turns out that reading and writing the temp file is CPU-bound rather
than I/O-bound (when run on imgr6, which has only one NVMe; on other
imaging machines with two in RAID-0, it will be even worse). Turning off
decompression on one test made the file about 20% bigger but reduced the
time for the whole imaging process by 35%.