### PR TITLE
Reuse sigproc templates

### DIFF
--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -803,9 +803,9 @@ class Clean(accel.OperationSequence):
         if `image_parameters` is inconsistent with the template
     """
     def __init__(self, template, command_queue, image_parameters, allocator=None):
-        if image_parameters.real_dtype != template.dtype:
+        if image_parameters.fixed.real_dtype != template.dtype:
             raise ValueError('dtype mismatch')
-        image_shape = (len(image_parameters.polarizations),
+        image_shape = (len(image_parameters.fixed.polarizations),
                        image_parameters.pixels, image_parameters.pixels)
         self._update_tiles = template._update_tiles.instantiate(
             command_queue, image_shape, template.clean_parameters.border, allocator)
@@ -993,7 +993,7 @@ class CleanHost:
         border = self.clean_parameters.border
         tiles_x = accel.divup(image.shape[2] - 2 * border, self.tile_size)
         tiles_y = accel.divup(image.shape[1] - 2 * border, self.tile_size)
-        self._tile_max = np.zeros((tiles_y, tiles_x), self.image_parameters.real_dtype)
+        self._tile_max = np.zeros((tiles_y, tiles_x), self.image_parameters.fixed.real_dtype)
         self._tile_pos = np.empty((tiles_y, tiles_x, 2), np.int32)
 
     def _update_tile(self, y, x):

--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -267,8 +267,8 @@ class NoiseEst(accel.Operation):
         Command queue for the operation
     image_shape : tuple of ints
         Shape for the dirty image
-    border : int
-        Distance from each edge of dirty image to ignore in ranking
+    border : float
+        Distance from each edge of dirty image to ignore in ranking, as fraction of image size
     allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
         Allocator used to allocate unbound slots
     """
@@ -276,13 +276,14 @@ class NoiseEst(accel.Operation):
     def __init__(self, template, command_queue, image_shape, border, allocator=None):
         if image_shape[0] != template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
-        if border * 2 >= min(image_shape[1], image_shape[2]):
+        if border >= 0.5:
             raise ValueError('Border must be less than half the image size')
         super().__init__(command_queue, allocator)
-        self._num_tiles_x = accel.divup(image_shape[2] - 2 * border, template.tilex)
-        self._num_tiles_y = accel.divup(image_shape[1] - 2 * border, template.tiley)
+        border_pixels = round(border * min(image_shape[1], image_shape[2]))
+        self._num_tiles_x = accel.divup(image_shape[2] - 2 * border_pixels, template.tilex)
+        self._num_tiles_y = accel.divup(image_shape[1] - 2 * border_pixels, template.tiley)
         self.template = template
-        self.border = border
+        self.border_pixels = border_pixels
         self.slots['dirty'] = accel.IOSlot([
             accel.Dimension(template.num_polarizations, exact=True),
             image_shape[1], image_shape[2]], template.dtype)
@@ -313,8 +314,8 @@ class NoiseEst(accel.Operation):
         rank = self.buffer('rank')
         rank_host = rank.empty_like()
         median_rank = (
-            (dirty.shape[1] - 2 * self.border)
-            * (dirty.shape[2] - 2 * self.border)
+            (dirty.shape[1] - 2 * self.border_pixels)
+            * (dirty.shape[2] - 2 * self.border_pixels)
             * self.template.num_polarizations // 2
         )
         # We don't need a super-accurate estimate down to the last bit.
@@ -336,9 +337,9 @@ class NoiseEst(accel.Operation):
                         dirty.buffer,
                         np.int32(dirty.padded_shape[2]),
                         np.int32(dirty.padded_shape[1] * dirty.padded_shape[2]),
-                        np.int32(dirty.shape[2] - self.border),
-                        np.int32(dirty.shape[1] - self.border),
-                        np.int32(self.border),
+                        np.int32(dirty.shape[2] - self.border_pixels),
+                        np.int32(dirty.shape[1] - self.border_pixels),
+                        np.int32(self.border_pixels),
                         rank.buffer,
                         mid
                     ],
@@ -421,8 +422,8 @@ class _UpdateTiles(accel.Operation):
         Command queue for the operation
     image_shape : tuple of ints
         Shape for the dirty image
-    border : int
-        Distance from each edge of dirty image where tiles start
+    border : float
+        Distance from each edge of dirty image where tiles start, as a fraction of image size
     allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
         Allocator used to allocate unbound slots
     """
@@ -430,18 +431,19 @@ class _UpdateTiles(accel.Operation):
     def __init__(self, template, command_queue, image_shape, border, allocator=None):
         if image_shape[0] != template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
-        if border * 2 >= min(image_shape[1], image_shape[2]):
+        if border >= 0.5:
             raise ValueError('Border must be less than half the image size')
         super().__init__(command_queue, allocator)
-        num_tiles_x = accel.divup(image_shape[2] - 2 * border, template.tilex)
-        num_tiles_y = accel.divup(image_shape[1] - 2 * border, template.tiley)
+        border_pixels = round(border * min(image_shape[1], image_shape[2]))
+        num_tiles_x = accel.divup(image_shape[2] - 2 * border_pixels, template.tilex)
+        num_tiles_y = accel.divup(image_shape[1] - 2 * border_pixels, template.tiley)
         image_width = accel.Dimension(image_shape[2])
         image_height = accel.Dimension(image_shape[1])
         image_pols = accel.Dimension(template.num_polarizations, exact=True)
         tiles_width = accel.Dimension(num_tiles_x)
         tiles_height = accel.Dimension(num_tiles_y)
         self.template = template
-        self.border = border
+        self.border_pixels = border_pixels
         self.slots['dirty'] = accel.IOSlot([image_pols, image_height, image_width], template.dtype)
         self.slots['tile_max'] = accel.IOSlot([tiles_height, tiles_width], template.dtype)
         self.slots['tile_pos'] = accel.IOSlot(
@@ -459,10 +461,10 @@ class _UpdateTiles(accel.Operation):
         tile_max = self.buffer('tile_max')
         tile_pos = self.buffer('tile_pos')
         # Map pixel range to a tile range
-        x0 = max((x0 - self.border) // self.template.tilex, 0)
-        y0 = max((y0 - self.border) // self.template.tiley, 0)
-        x1 = min(accel.divup(x1 - self.border, self.template.tilex), tile_max.shape[1])
-        y1 = min(accel.divup(y1 - self.border, self.template.tiley), tile_max.shape[0])
+        x0 = max((x0 - self.border_pixels) // self.template.tilex, 0)
+        y0 = max((y0 - self.border_pixels) // self.template.tiley, 0)
+        x1 = min(accel.divup(x1 - self.border_pixels, self.template.tilex), tile_max.shape[1])
+        y1 = min(accel.divup(y1 - self.border_pixels, self.template.tiley), tile_max.shape[0])
         if x0 < x1 and y0 < y1:
             dirty = self.buffer('dirty')
             with profile_device(self.command_queue, 'update_tiles'):
@@ -472,9 +474,9 @@ class _UpdateTiles(accel.Operation):
                         dirty.buffer,
                         np.int32(dirty.padded_shape[2]),
                         np.int32(dirty.padded_shape[1] * dirty.padded_shape[2]),
-                        np.int32(dirty.shape[2] - self.border),
-                        np.int32(dirty.shape[1] - self.border),
-                        np.int32(self.border),
+                        np.int32(dirty.shape[2] - self.border_pixels),
+                        np.int32(dirty.shape[1] - self.border_pixels),
+                        np.int32(self.border_pixels),
                         tile_max.buffer,
                         tile_pos.buffer,
                         np.int32(tile_max.padded_shape[1]),
@@ -792,8 +794,6 @@ class Clean(accel.OperationSequence):
         Command queue for the operation
     image_parameters : :class:`katsdpimager.parameters.ImageParameters`
         Command-line parameters with image properties
-    border : int
-        Size of border in which no components may be placed
     allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
         Allocator used to allocate unbound slots
 
@@ -935,7 +935,8 @@ def psf_patch_host(psf, threshold, limit=None):
 
 def noise_est_host(image, border):
     """Host implementation of :class:`NoiseEstTemplate`."""
-    image = image[:, border:-border, border:-border]
+    border_pixels = round(border * min(image.shape[1], image.shape[2]))
+    image = image[:, border_pixels:-border_pixels, border_pixels:-border_pixels]
     median = np.median(np.abs(image))
     return median * _MEDIAN_TO_RMS
 
@@ -983,6 +984,7 @@ class CleanHost:
     model : ndarray, (height, width, num_polarizations), real
         Model image, which is updated with found CLEAN components
     """
+
     def __init__(self, image_parameters, clean_parameters, image, psf, model):
         self.clean_parameters = clean_parameters
         self.image_parameters = image_parameters
@@ -990,18 +992,17 @@ class CleanHost:
         self.model = model
         self.psf = psf
         self.tile_size = 32
-        border = self.clean_parameters.border
-        tiles_x = accel.divup(image.shape[2] - 2 * border, self.tile_size)
-        tiles_y = accel.divup(image.shape[1] - 2 * border, self.tile_size)
+        self.border_pixels = round(image_parameters.pixels * clean_parameters.border)
+        tiles_x = accel.divup(image.shape[2] - 2 * self.border_pixels, self.tile_size)
+        tiles_y = accel.divup(image.shape[1] - 2 * self.border_pixels, self.tile_size)
         self._tile_max = np.zeros((tiles_y, tiles_x), self.image_parameters.fixed.real_dtype)
         self._tile_pos = np.empty((tiles_y, tiles_x, 2), np.int32)
 
     def _update_tile(self, y, x):
-        border = self.clean_parameters.border
-        x0 = x * self.tile_size + border
-        y0 = y * self.tile_size + border
-        x1 = min(x0 + self.tile_size, self.image.shape[2] - border)
-        y1 = min(y0 + self.tile_size, self.image.shape[1] - border)
+        x0 = x * self.tile_size + self.border_pixels
+        y0 = y * self.tile_size + self.border_pixels
+        x1 = min(x0 + self.tile_size, self.image.shape[2] - self.border_pixels)
+        y1 = min(y0 + self.tile_size, self.image.shape[1] - self.border_pixels)
         best_pos, best_value = _tile_peak(
             y0, x0, y1, x1, self.image, self.clean_parameters.mode,
             self.image.dtype.type(0))
@@ -1062,11 +1063,10 @@ class CleanHost:
         if peak_value < threshold:
             return None
         (y0, x0, y1, x1) = self._subtract_psf(peak_pos[0], peak_pos[1], psf_patch)
-        border = self.clean_parameters.border
-        tile_y0 = max((y0 - border) // self.tile_size, 0)
-        tile_x0 = max((x0 - border) // self.tile_size, 0)
-        tile_y1 = min(accel.divup(y1 - border, self.tile_size), self._tile_max.shape[0])
-        tile_x1 = min(accel.divup(x1 - border, self.tile_size), self._tile_max.shape[1])
+        tile_y0 = max((y0 - self.border_pixels) // self.tile_size, 0)
+        tile_x0 = max((x0 - self.border_pixels) // self.tile_size, 0)
+        tile_y1 = min(accel.divup(y1 - self.border_pixels, self.tile_size), self._tile_max.shape[0])
+        tile_x1 = min(accel.divup(x1 - self.border_pixels, self.tile_size), self._tile_max.shape[1])
         for y in range(tile_y0, tile_y1):
             for x in range(tile_x0, tile_x1):
                 self._update_tile(y, x)

--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -134,7 +134,7 @@ class PsfPatch(accel.Operation):
         mid_x = psf.shape[2] // 2
         mid_y = psf.shape[1] // 2
         if limit is not None:
-            hlimit = (limit - 1) // 2
+            hlimit = (round(limit * min(psf.shape[1], psf.shape[2])) - 1) // 2
             min_x = max(min_x, mid_x - hlimit)
             min_y = max(min_y, mid_y - hlimit)
             max_x = min(max_x, mid_x + hlimit)
@@ -912,7 +912,7 @@ def psf_patch_host(psf, threshold, limit=None):
         dimensions. The size is always even.
     """
     if limit is not None:
-        hlimit = (limit - 1) // 2
+        hlimit = (round(limit * min(psf.shape[1], psf.shape[2])) - 1) // 2
         mid_x = psf.shape[2] // 2
         mid_y = psf.shape[1] // 2
         min_x = max(0, mid_x - hlimit)

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -487,10 +487,10 @@ def process_channel(dataset, args, start_channel,
     else:
         allocator = accel.SVMAllocator(context)
         imager_template = imaging.ImagingTemplate(
-            context, array_p, image_p, weight_p, grid_p, clean_p)
+            context, array_p, image_p.fixed, weight_p, grid_p.fixed, clean_p)
         n_sources = len(subtract_model) if subtract_model else 0
         imager = imager_template.instantiate(
-            queue, args.vis_block, n_sources, args.major, allocator)
+            queue, image_p, grid_p, args.vis_block, n_sources, args.major, allocator)
         imager.ensure_all_bound()
     psf = imager.buffer('psf')
     dirty = imager.buffer('dirty')

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -266,10 +266,9 @@ class ChannelParameters:
             clean_mode = clean.CLEAN_SUMSQ
         else:
             raise ValueError('Unhandled --clean-mode {}'.format(args.clean_mode))
-        limit = int(round(self.image_p.pixels * args.psf_limit))
         self.clean_p = parameters.CleanParameters(
             args.minor, args.loop_gain, args.major_gain, args.threshold,
-            clean_mode, args.psf_cutoff, limit, args.border)
+            clean_mode, args.psf_cutoff, args.psf_limit, args.border)
 
     def log_parameters(self, suffix=''):
         log_parameters("Image parameters" + suffix, self.image_p)

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -487,9 +487,10 @@ def process_channel(dataset, args, start_channel,
     else:
         allocator = accel.SVMAllocator(context)
         imager_template = imaging.ImagingTemplate(
-            queue, array_p, image_p, weight_p, grid_p, clean_p)
+            context, array_p, image_p, weight_p, grid_p, clean_p)
         n_sources = len(subtract_model) if subtract_model else 0
-        imager = imager_template.instantiate(args.vis_block, n_sources, args.major, allocator)
+        imager = imager_template.instantiate(
+            queue, args.vis_block, n_sources, args.major, allocator)
         imager.ensure_all_bound()
     psf = imager.buffer('psf')
     dirty = imager.buffer('dirty')

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -266,11 +266,10 @@ class ChannelParameters:
             clean_mode = clean.CLEAN_SUMSQ
         else:
             raise ValueError('Unhandled --clean-mode {}'.format(args.clean_mode))
-        border = int(round(self.image_p.pixels * args.border))
         limit = int(round(self.image_p.pixels * args.psf_limit))
         self.clean_p = parameters.CleanParameters(
             args.minor, args.loop_gain, args.major_gain, args.threshold,
-            clean_mode, args.psf_cutoff, limit, border)
+            clean_mode, args.psf_cutoff, limit, args.border)
 
     def log_parameters(self, suffix=''):
         log_parameters("Image parameters" + suffix, self.image_p)

--- a/katsdpimager/io.py
+++ b/katsdpimager/io.py
@@ -161,7 +161,7 @@ def write_fits_image(dataset, image, image_parameters, filename, channel,
         header['BMAJ'] = major.to(units.deg).value
         header['BMIN'] = minor.to(units.deg).value
         header['BPA'] = beam.theta.to(units.deg).value
-    _fits_polarizations(header, 3, image_parameters.polarizations)
+    _fits_polarizations(header, 3, image_parameters.fixed.polarizations)
     # This is basically np.nanmin and np.nanmax, but the implementations of
     # those take a slow, safe path if the array is a subclass of ndarray. In
     # our case it is but the fast path still works so we use it directly.
@@ -235,7 +235,7 @@ def write_fits_grid(grid, image_parameters, filename, channel):
         If the set of `polarizations` cannot be represented as a linear
         transform in the FITS header.
     """
-    grid = _split_array(grid, image_parameters.real_dtype)
+    grid = _split_array(grid, image_parameters.fixed.real_dtype)
     grid = grid.transpose(3, 0, 1, 2)
 
     header = fits.Header()
@@ -249,7 +249,7 @@ def write_fits_grid(grid, image_parameters, filename, channel):
     header['CRPIX2'] = grid.shape[2] // 2 + 1.0
     header['CRVAL2'] = 0.0
     header['CDELT2'] = float(image_parameters.cell_size / units.m)
-    pol_permute = _fits_polarizations(header, 3, image_parameters.polarizations)
+    pol_permute = _fits_polarizations(header, 3, image_parameters.fixed.polarizations)
     header['CTYPE4'] = 'COMPLEX'
     header['CRPIX4'] = 1.0
     header['CRVAL4'] = 1.0

--- a/katsdpimager/parameters.py
+++ b/katsdpimager/parameters.py
@@ -286,13 +286,13 @@ class CleanParameters:
         self.border = border
 
     def __str__(self):
-        return """\
+        mode = 'I' if self.mode == clean.CLEAN_I else 'I^2+Q^2+U^2+V^2'
+        return f"""\
 Loop gain: {self.loop_gain}
 Major cycle gain: {self.major_gain}
 Threshold: {self.threshold} sigma
 Max minor cycles: {self.minor}
 PSF cutoff: {self.psf_cutoff}
-PSF limit: {self.psf_limit} pixels
+PSF limit: {self.psf_limit * 100}%
 Peak function: {mode}
-Border: {100 * self.border}%""".format(
-            self=self, mode='I' if self.mode == clean.CLEAN_I else 'I^2+Q^2+U^2+V^2')
+Border: {self.border * 100}%"""

--- a/katsdpimager/parameters.py
+++ b/katsdpimager/parameters.py
@@ -294,5 +294,5 @@ Max minor cycles: {self.minor}
 PSF cutoff: {self.psf_cutoff}
 PSF limit: {self.psf_limit} pixels
 Peak function: {mode}
-Border: {self.border} pixels""".format(
+Border: {100 * self.border}%""".format(
             self=self, mode='I' if self.mode == clean.CLEAN_I else 'I^2+Q^2+U^2+V^2')

--- a/katsdpimager/preprocess.py
+++ b/katsdpimager/preprocess.py
@@ -87,16 +87,16 @@ class VisibilityCollector(_preprocess.VisibilityCollector):
         Number of visibilities to buffer, prior to compression
     """
     def __init__(self, image_parameters, grid_parameters, buffer_size):
-        num_polarizations = len(image_parameters[0].polarizations)
+        num_polarizations = len(image_parameters[0].fixed.polarizations)
         if len(image_parameters) != len(grid_parameters):
             raise ValueError('Inconsistent lengths of image_parameters and grid_parameters')
         num_channels = len(image_parameters)
         config = np.zeros(num_channels, _preprocess.CHANNEL_CONFIG_DTYPE)
         for i, grid_p in enumerate(grid_parameters):
-            config[i]["max_w"] = grid_p.max_w.to(units.m).value
+            config[i]["max_w"] = grid_p.fixed.max_w.to(units.m).value
             config[i]["w_slices"] = grid_p.w_slices
             config[i]["w_planes"] = grid_p.w_planes
-            config[i]["oversample"] = grid_p.oversample
+            config[i]["oversample"] = grid_p.fixed.oversample
             config[i]["cell_size"] = image_parameters[i].cell_size.to(units.m).value
         super().__init__(
             num_polarizations, config, self._emit, buffer_size)

--- a/katsdpimager/test/test_clean.py
+++ b/katsdpimager/test/test_clean.py
@@ -79,7 +79,8 @@ class TestClean:
     @device_test
     def test_update_tiles(self, context, command_queue):
         image_shape = (4, 567, 456)
-        border = 65
+        border_pixels = 65
+        border = border_pixels / image_shape[2]
         rs = np.random.RandomState(seed=1)
         template = clean._UpdateTilesTemplate(context, np.float32, 4, clean.CLEAN_I)
         fn = template.instantiate(command_queue, image_shape, border)
@@ -104,10 +105,10 @@ class TestClean:
                     assert_equal(0, tile_pos[y, x, 0])
                     assert_equal(0, tile_pos[y, x, 1])
                 else:
-                    y0 = y * template.tiley + border
-                    x0 = x * template.tilex + border
-                    y1 = min(y0 + template.tiley, dirty.shape[1] - border)
-                    x1 = min(x0 + template.tilex, dirty.shape[2] - border)
+                    y0 = y * template.tiley + border_pixels
+                    x0 = x * template.tilex + border_pixels
+                    y1 = min(y0 + template.tiley, dirty.shape[1] - border_pixels)
+                    x1 = min(x0 + template.tilex, dirty.shape[2] - border_pixels)
                     tile = np.abs(dirty[0, y0:y1, x0:x1])
                     pos = np.unravel_index(np.argmax(tile), tile.shape)
                     assert_equal(tile[pos], tile_max[y, x])
@@ -173,12 +174,13 @@ class TestClean:
     def _test_noise(self, context, command_queue, std, rtol):
         rs = np.random.RandomState(seed=1)
         image_shape = (4, 400, 544)
-        border = 45
+        border_pixels = 45
+        border = border_pixels / image_shape[1]
         # Start with a standard normal distribution
         dirty = rs.standard_normal(image_shape).astype(np.float32)
         # Scale it up only inside the border, to ensure that the border value
         # is being respected.
-        dirty[:, border:-border, border:-border] *= std
+        dirty[:, border_pixels:-border_pixels, border_pixels:-border_pixels] *= std
         # Add some big values to ensure robustness
         dirty.flat[rs.choice(dirty.size, 1000, replace=False)] += 1e6
 

--- a/katsdpimager/test/test_clean.py
+++ b/katsdpimager/test/test_clean.py
@@ -34,7 +34,7 @@ class _TestPsfPatchBase:
         self.psf_host[0, 0, 0] = 0.4
         self.psf_host[3, 205, 303] = 0.3
         self.psf_host[1, 110, 150] = 0.2
-        assert_equal((4, 15, 5), self._test(limit=50))
+        assert_equal((4, 15, 5), self._test(limit=50 / 206))
 
 
 class TestPsfPatch(_TestPsfPatchBase):

--- a/katsdpimager/test/test_grid.py
+++ b/katsdpimager/test/test_grid.py
@@ -141,9 +141,14 @@ class TestGridder(BaseTest):
     @device_test
     def test(self, context, command_queue):
         def callback(max_vis, vis):
-            template = grid.GridderTemplate(context, self.image_parameters, self.grid_parameters)
-            fn = template.instantiate(command_queue, self.array_parameters, max_vis,
-                                      allocator=accel.SVMAllocator(context))
+            template = grid.GridderTemplate(
+                context, self.image_parameters.fixed, self.grid_parameters.fixed)
+            fn = template.instantiate(
+                command_queue,
+                self.array_parameters,
+                self.image_parameters,
+                self.grid_parameters,
+                max_vis, allocator=accel.SVMAllocator(context))
             fn.ensure_all_bound()
             grid_data = fn.buffer('grid')
             grid_data.fill(0)
@@ -163,7 +168,7 @@ class TestGridder(BaseTest):
     @force_autotune
     def test_autotune(self, context, queue):
         """Check that the autotuner runs successfully"""
-        grid.GridderTemplate(context, self.image_parameters_sp, self.grid_parameters)
+        grid.GridderTemplate(context, self.image_parameters_sp.fixed, self.grid_parameters.fixed)
 
 
 class TestGridderHost(BaseTest):
@@ -187,9 +192,14 @@ class TestDegridder(BaseTest):
     def test(self, context, command_queue):
         def callback(max_vis, grid_data, weights, vis):
             n_vis = len(self.w_plane)
-            template = grid.DegridderTemplate(context, self.image_parameters, self.grid_parameters)
-            fn = template.instantiate(command_queue, self.array_parameters, max_vis,
-                                      allocator=accel.SVMAllocator(context))
+            template = grid.DegridderTemplate(
+                context, self.image_parameters.fixed, self.grid_parameters.fixed)
+            fn = template.instantiate(
+                command_queue,
+                self.array_parameters,
+                self.image_parameters,
+                self.grid_parameters,
+                max_vis, allocator=accel.SVMAllocator(context))
             fn.ensure_all_bound()
             grid_buffer = fn.buffer('grid')
             grid_buffer.set(command_queue, _middle(grid_data, grid_buffer.shape))
@@ -206,7 +216,7 @@ class TestDegridder(BaseTest):
     @force_autotune
     def test_autotune(self, context, queue):
         """Check that the autotuner runs successfully"""
-        grid.DegridderTemplate(context, self.image_parameters_sp, self.grid_parameters)
+        grid.DegridderTemplate(context, self.image_parameters_sp.fixed, self.grid_parameters.fixed)
 
 
 class TestDegridderHost(BaseTest):

--- a/katsdpimager/test/test_grid.py
+++ b/katsdpimager/test/test_grid.py
@@ -32,32 +32,37 @@ class BaseTest:
         kernel_width = 28
         assert grid_cover + kernel_width < pixels
         self.image_parameters = parameters.ImageParameters(
+            parameters.FixedImageParameters(
+                polarizations=polarization.STOKES_IQUV, dtype=np.float64
+            ),
             q_fov=1.0,
             image_oversample=None,
             frequency=0.01 * units.m,
             array=None,
-            polarizations=polarization.STOKES_IQUV,
-            dtype=np.float64,
             pixel_size=0.0001,
             pixels=pixels)
         # Make a single-precision version for cases that don't need double
         self.image_parameters_sp = parameters.ImageParameters(
+            parameters.FixedImageParameters(
+                polarizations=polarization.STOKES_IQUV, dtype=np.float32
+            ),
             q_fov=1.0,
             image_oversample=None,
             frequency=self.image_parameters.wavelength,
             array=None,
-            polarizations=self.image_parameters.polarizations,
-            dtype=np.float32,
             pixel_size=self.image_parameters.pixel_size,
             pixels=self.image_parameters.pixels)
         self.grid_parameters = parameters.GridParameters(
-            antialias_width=7.0,
-            oversample=oversample,
-            image_oversample=4,
+            parameters.FixedGridParameters(
+                antialias_width=7.0,
+                oversample=oversample,
+                image_oversample=4,
+                max_w=5 * units.m,
+                kernel_width=kernel_width
+            ),
             w_slices=1,
-            w_planes=w_planes,
-            max_w=5 * units.m,
-            kernel_width=kernel_width)
+            w_planes=w_planes
+        )
         self.array_parameters = mock.Mock()
         self.array_parameters.longest_baseline = self.image_parameters.cell_size * (grid_cover // 2)
         # Create a track in which movement happens in various subsets of the

--- a/katsdpimager/test/test_preprocess.py
+++ b/katsdpimager/test/test_preprocess.py
@@ -22,23 +22,29 @@ class BaseTestVisibilityCollector:
     def setup(self):
         self.image_parameters = []
         self.grid_parameters = []
+        fixed_image_parameters = parameters.FixedImageParameters(
+            polarizations=polarization.STOKES_IQUV,
+            dtype=np.float32
+        )
+        fixed_grid_parameters = parameters.FixedGridParameters(
+            antialias_width=7.0,
+            oversample=8,
+            image_oversample=4.0,
+            max_w=400 * units.m,
+            kernel_width=64
+        )
         for wavelength in np.array([0.25, 0.125]) * units.m:
             self.image_parameters.append(parameters.ImageParameters(
+                fixed_image_parameters,
                 q_fov=1.0,
                 image_oversample=5.0,
                 frequency=wavelength, array=None,
-                polarizations=polarization.STOKES_IQUV,
-                dtype=np.float32,
                 pixel_size=1.0/(4096.0*wavelength.value),
                 pixels=2048))
             self.grid_parameters.append(parameters.GridParameters(
-                antialias_width=7.0,
-                oversample=8,
-                image_oversample=4.0,
+                fixed_grid_parameters,
                 w_slices=1,
-                w_planes=128,
-                max_w=400 * units.m,
-                kernel_width=64))
+                w_planes=128))
 
     def check(self, collector, expected):
         reader = collector.reader()

--- a/scripts/imager-mkat-pipeline.py
+++ b/scripts/imager-mkat-pipeline.py
@@ -146,9 +146,11 @@ class Writer(frontend.Writer):
         self._set_statistic('cell_size', sub_key, image_p.cell_size.to_value(u.m))
 
         grid_p = kwargs['grid_parameters']
-        for key in ['image_oversample', 'w_slices', 'w_planes', 'kernel_width']:
+        for key in ['image_oversample', 'kernel_width']:
+            self._set_statistic(key, sub_key, getattr(grid_p.fixed, key))
+        for key in ['w_slices', 'w_planes']:
             self._set_statistic(key, sub_key, getattr(grid_p, key))
-        self._set_statistic('grid_oversample', sub_key, grid_p.oversample)
+        self._set_statistic('grid_oversample', sub_key, grid_p.fixed.oversample)
 
         # statistics() is the last step in process_channel, so if we get this
         # far, the channel is fully processed.


### PR DESCRIPTION
Avoid recompiling the CUDA kernels and related infrastructure for every channel. This reduces runtime by around 15% (in one test - probably less for longer observations since the cost is amortised).

It's a big diff for a fairly small functional change, which is due to refactoring to split out channel-independent pieces:
- New `FixedImageParameters` and `FixedGridParameters` classes hold only channel-independent information, and are referenced by the full `ImageParameters` and `GridParameters`.
- The convolution kernel is moved from `GridderTemplate` (and `DegridderTemplate`) to `GridDegrid`, so that the former can be channel-independent.
- The `psf_patch` and `border` fields in `CleanParameters` are now fractions of the image size (as specified on the command line) and converted to pixel counts (named `psf_patch_pixels` and `border_pixels`) when needed, so that `CleanParameters` is channel-independent (while the MeerKAT pipeline arguments have a fixed pixel count across channels, I think the imager can also be run with fixed resolution, variable field-of-view and hence variable pixel counts).

I'd particularly welcome careful review on frontend.py, because it doesn't get covered by unit tests.