### PR TITLE
Change sorting approach for preprocessing

### DIFF
--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -40,7 +40,7 @@ def preprocess_visibilities(dataset, args, start_channel, stop_channel,
             if bar is None:
                 bar = progress.make_progressbar("Preprocessing vis", max=chunk['total'])
             collector.add(
-                chunk['uvw'], chunk['weights'], chunk['baselines'], chunk['vis'],
+                chunk['uvw'], chunk['weights'], chunk['vis'],
                 chunk.get('feed_angle1'), chunk.get('feed_angle2'),
                 *polarization_matrices)
             bar.goto(chunk['progress'])

--- a/katsdpimager/loader_core.py
+++ b/katsdpimager/loader_core.py
@@ -150,7 +150,6 @@ class LoaderBase(ABC):
          - ``uvw``: UVW coordinates (position2 - position1), as a Quantity (N×3)
          - ``vis``: visibilities (C×N×P for C channels and P polarizations)
          - ``weights``: imaging weights (C×N×P for C channels and P polarizations)
-         - ``baselines``: arbitrary integer baseline IDs; negative IDs indicate autocorrelations
          - ``feed_angle1``: angle between feed and sky (parallactic angle plus a fixed
            offset for the feed), for the first antenna in the baseline (N).
          - ``feed_angle2``: angle between feed and sky for the second antenna in
@@ -177,7 +176,8 @@ class LoaderBase(ABC):
            .. _CASA: http://casa.nrao.edu/Memos/CoordConvention.pdf
 
         The arrays are indexed first by channel (where applicable) then by a 1D
-        time/baseline coordinate. The second index is x/y/z for 'uvw' and
+        time/baseline coordinate (which for best performance should be
+        baseline-major). The second index is x/y/z for 'uvw' and
         polarization product for 'vis' and 'weights'.  Flags are not explicitly
         returned: they are either omitted entirely (if all pols are flagged) or
         indicated with a zero weight.

--- a/katsdpimager/loader_katdal.py
+++ b/katsdpimager/loader_katdal.py
@@ -298,7 +298,6 @@ class LoaderKatdal(loader_core.LoaderBase):
         # timestamps is a property, so ensure it's only evaluated once
         with profile('katdal.DataSet.timestamps'):
             timestamps = self._file.timestamps
-        baseline_idx = np.arange(len(self._baselines)).astype(np.int32)
         start = 0
         # Determine chunking scheme
         if isinstance(self._file.vis, DaskLazyIndexer):
@@ -378,7 +377,6 @@ class LoaderKatdal(loader_core.LoaderBase):
             yield dict(
                 uvw=uvw.reshape(-1, 3),
                 weights=reorder(weights),
-                baselines=np.repeat(baseline_idx, end - start),
                 vis=reorder(vis),
                 feed_angle1=feed_angle1.reshape(-1),
                 feed_angle2=feed_angle2.reshape(-1),

--- a/katsdpimager/loader_ms.py
+++ b/katsdpimager/loader_ms.py
@@ -463,15 +463,17 @@ class LoaderMS(loader_core.LoaderBase):
                                    start, nrows)[valid, ...]
             weight = weight * np.logical_not(flag)
             baseline = (antenna1 * self._antenna.nrows() + antenna2)
-            ret = dict(uvw=uvw,
-                       weights=np.swapaxes(weight, 0, 1),
-                       baselines=baseline,
-                       vis=np.swapaxes(data, 0, 1),
+            # Order data by baseline to facilitate compression
+            order = np.argsort(baseline, kind='stable')
+            ret = dict(uvw=uvw[order],
+                       weights=np.swapaxes(weight, 0, 1)[:, order],
+                       baselines=baseline[order],
+                       vis=np.swapaxes(data, 0, 1)[:, order],
                        progress=end,
                        total=self._main.nrows())
             if self._feed_angle_correction:
-                ret['feed_angle1'] = feed_angle1
-                ret['feed_angle2'] = feed_angle2
+                ret['feed_angle1'] = feed_angle1[order]
+                ret['feed_angle2'] = feed_angle2[order]
             yield ret
 
     @property

--- a/katsdpimager/loader_ms.py
+++ b/katsdpimager/loader_ms.py
@@ -467,7 +467,6 @@ class LoaderMS(loader_core.LoaderBase):
             order = np.argsort(baseline, kind='stable')
             ret = dict(uvw=uvw[order],
                        weights=np.swapaxes(weight, 0, 1)[:, order],
-                       baselines=baseline[order],
                        vis=np.swapaxes(data, 0, 1)[:, order],
                        progress=end,
                        total=self._main.nrows())

--- a/katsdpimager/preprocess.py
+++ b/katsdpimager/preprocess.py
@@ -108,7 +108,7 @@ class VisibilityCollector(_preprocess.VisibilityCollector):
     def num_channels(self):
         return len(self.image_parameters)
 
-    def _emit(self, elements):
+    def _emit(self, channel, elements):
         """Write an array of compressed elements with the same channel and w
         slice to the backing store. The caller must provide a non-empty
         array.
@@ -237,9 +237,8 @@ class VisibilityCollectorHDF5(VisibilityCollector):
             dtype=self.store_dtype,
             chunks=(1, 1, chunk_elements))
 
-    def _emit(self, elements):
+    def _emit(self, channel, elements):
         N = elements.shape[0]
-        channel = elements[0]['channel']
         w_slice = elements[0]['w_slice']
         old_length = self._length[channel, w_slice]
         self._length[channel, w_slice] += N
@@ -287,8 +286,8 @@ class VisibilityCollectorMem(VisibilityCollector):
             [[] for w_slice in range(self.grid_parameters[channel].w_slices)]
             for channel in range(self.num_channels)]
 
-    def _emit(self, elements):
-        dataset = self.datasets[elements[0]['channel']][elements[0]['w_slice']]
+    def _emit(self, channel, elements):
+        dataset = self.datasets[channel][elements[0]['w_slice']]
         # Work around FutureWarning in numpy 1.12 by first creating a view of
         # elements that contains only the fields we want.
         elements = np.ndarray(elements.shape, self.store_dtype, elements, 0, elements.strides)

--- a/katsdpimager/preprocess.py
+++ b/katsdpimager/preprocess.py
@@ -117,10 +117,13 @@ class VisibilityCollector(_preprocess.VisibilityCollector):
         """
         raise NotImplementedError()
 
-    def add(self, uvw, weights, baselines, vis,
+    def add(self, uvw, weights, vis,
             feed_angle1, feed_angle2, mueller_stokes, mueller_circular):
-        """Add a set of visibilities to the collector. Each of the provided
-        arrays must have the same size on the N axis.
+        """Add a set of visibilities to the collector.
+
+        Each of the provided arrays must have the same size on the N axis.
+        For best performance, order the visibilities by baseline then time,
+        so that consecutive visibilities have similar UVW coordinates.
 
         Parameters
         ----------
@@ -130,12 +133,6 @@ class VisibilityCollector(_preprocess.VisibilityCollector):
             C×N×Q array of weights, where C is the number of channels and
             Q is the number of input polarizations. Flags must be folded into
             the weights.
-        baselines : array, int
-            1D array of integer, indicating baseline IDs. The IDs are
-            arbitrary and need not be contiguous, and are used only to
-            associate visibilities from the same baseline together.
-            Negative baseline IDs indicate autocorrelations, which will
-            be discarded.
         vis : array, complex64
             C×N×Q array of visibilities.
         feed_angle1, feed_angle2 : array, float32
@@ -152,7 +149,7 @@ class VisibilityCollector(_preprocess.VisibilityCollector):
         uvw = units.Quantity(uvw, unit=units.m, copy=False)
         uvw = np.require(uvw.value, np.float32, 'C')
         super().add(
-            uvw, weights, baselines, vis, feed_angle1, feed_angle2,
+            uvw, weights, vis, feed_angle1, feed_angle2,
             mueller_stokes, mueller_circular)
 
     def reader(self):

--- a/katsdpimager/test/test_preprocess.py
+++ b/katsdpimager/test/test_preprocess.py
@@ -64,9 +64,9 @@ class BaseTestVisibilityCollector:
                     # well, so test one field at a time.
                     np.testing.assert_array_equal(actual.uv, slice_data.uv)
                     np.testing.assert_array_equal(actual.sub_uv, slice_data.sub_uv)
+                    np.testing.assert_array_equal(actual.w_plane, slice_data.w_plane)
                     np.testing.assert_allclose(actual.weights, slice_data.weights)
                     np.testing.assert_allclose(actual.vis, slice_data.vis, rtol=1e-5)
-                    np.testing.assert_array_equal(actual.w_plane, slice_data.w_plane)
 
     def test_empty(self):
         with closing(self.factory(self.image_parameters, self.grid_parameters, 2)) as collector:
@@ -77,43 +77,43 @@ class BaseTestVisibilityCollector:
         uvw = np.array([
             [12.1, 2.3, 4.7],
             [-3.4, 7.6, 2.5],
-            [-5.2, -10.6, 7.2],
             [12.102, 2.299, 4.6],   # Should merge with the first visibility in first channel
+            [-5.2, -10.6, 7.2],
             [-1.0, 2.0, 3.0]
         ], dtype=np.float32) * units.m
         weights = np.array([
             [
                 [1.3, 0.6, 1.2, 0.1],
                 [1.0, 1.0, 1.0, 1.0],
-                [0.5, 0.6, 0.7, 0.8],
                 [1.1, 1.2, 1.3, 1.4],
+                [0.5, 0.6, 0.7, 0.8],
                 [1.0, 0.0, 1.0, 1.0]    # Has a zero weight, so should be skipped
             ], [
                 [0.2, 2.4, 1.2, 2.6],   # Second channel is double and reverse of first
                 [2.0, 2.0, 2.0, 2.0],
-                [1.6, 1.4, 1.2, 1.0],
                 [2.8, 2.6, 2.4, 2.2],
+                [1.6, 1.4, 1.2, 1.0],
                 [2.0, 2.0, 0.0, 2.0]
             ]], dtype=np.float32)
         baselines = np.array([
             0,
             -1,    # Auto-correlation: should be removed
-            1,
             0,
+            1,
             0
         ], dtype=np.int16)
         vis = np.array([
             [
                 [0.5 - 2.3j, 0.1 + 4.2j, 0.0 - 3j, 1.5 + 0j],
                 [0.5 - 2.3j, 0.1 + 4.2j, 0.0 - 3j, 1.5 + 0j],
-                [1.5 + 1.3j, 1.1 + 2.7j, 1.0 - 2j, 2.5 + 1j],
                 [1.2 + 3.4j, 5.6 + 7.8j, 9.0 + 1.2j, 3.4 + 5.6j],
+                [1.5 + 1.3j, 1.1 + 2.7j, 1.0 - 2j, 2.5 + 1j],
                 [10.0, 10.0, 10.0, 10.0]
             ], [
                 [3.0 + 0j, 0.0 - 6j, 0.2 + 8.4j, 1.0 - 4.6j],
                 [3.0 + 0j, 0.0 - 6j, 0.2 + 8.4j, 1.0 - 4.6j],
-                [3.0 + 2j, 2.0 - 4j, 2.2 + 5.4j, 3.0 + 2.6j],
                 [6.8 + 11.2j, 18.0 + 2.4j, 11.2 + 15.6j, 2.4 + 6.8j],
+                [3.0 + 2j, 2.0 - 4j, 2.2 + 5.4j, 3.0 + 2.6j],
                 [20.0, 20.0, 20.0, 20.0]
             ]], dtype=np.complex64)
         if use_feed_angles:
@@ -131,18 +131,20 @@ class BaseTestVisibilityCollector:
             [np.rec.fromarrays([
                 [[96, 18], [-42, -85]],
                 [[6, 3], [3, 1]],
+                [64, 65],
                 [[2.4, 1.8, 2.5, 1.5], [0.5, 0.6, 0.7, 0.8]],
                 [[1.97 + 0.75j, 6.78 + 11.88j, 11.7 - 2.04j, 4.91 + 7.84j],
-                 [0.75 + 0.65j, 0.66 + 1.62j, 0.7 - 1.4j, 2.0 + 0.8j]],
-                [64, 65]], dtype=collector.store_dtype)],
+                 [0.75 + 0.65j, 0.66 + 1.62j, 0.7 - 1.4j, 2.0 + 0.8j]]],
+                dtype=collector.store_dtype)],
             [np.rec.fromarrays([
                 [[387, 73], [387, 73], [-167, -340]],
                 [[1, 4], [2, 4], [4, 6]],
+                [64, 64, 65],
                 [[0.2, 2.4, 1.2, 2.6], [2.8, 2.6, 2.4, 2.2], [1.6, 1.4, 1.2, 1.0]],
                 [[0.6 + 0.0j, 0.0 - 14.4j, 0.24 + 10.08j, 2.6 - 11.96j],
                  [19.04 + 31.36j, 46.8 + 6.24j, 26.88 + 37.44j, 5.28 + 14.96j],
-                 [4.8 + 3.2j, 2.8 - 5.6j, 2.64 + 6.48j, 3.0 + 2.6j]],
-                [64, 64, 65]], dtype=collector.store_dtype)]
+                 [4.8 + 3.2j, 2.8 - 5.6j, 2.64 + 6.48j, 3.0 + 2.6j]]],
+                dtype=collector.store_dtype)]
         ])
 
     def test_simple(self):

--- a/katsdpimager/test/test_preprocess.py
+++ b/katsdpimager/test/test_preprocess.py
@@ -76,7 +76,6 @@ class BaseTestVisibilityCollector:
     def _test_impl(self, use_feed_angles):
         uvw = np.array([
             [12.1, 2.3, 4.7],
-            [-3.4, 7.6, 2.5],
             [12.102, 2.299, 4.6],   # Should merge with the first visibility in first channel
             [-5.2, -10.6, 7.2],
             [-1.0, 2.0, 3.0]
@@ -84,33 +83,22 @@ class BaseTestVisibilityCollector:
         weights = np.array([
             [
                 [1.3, 0.6, 1.2, 0.1],
-                [1.0, 1.0, 1.0, 1.0],
                 [1.1, 1.2, 1.3, 1.4],
                 [0.5, 0.6, 0.7, 0.8],
                 [1.0, 0.0, 1.0, 1.0]    # Has a zero weight, so should be skipped
             ], [
                 [0.2, 2.4, 1.2, 2.6],   # Second channel is double and reverse of first
-                [2.0, 2.0, 2.0, 2.0],
                 [2.8, 2.6, 2.4, 2.2],
                 [1.6, 1.4, 1.2, 1.0],
                 [2.0, 2.0, 0.0, 2.0]
             ]], dtype=np.float32)
-        baselines = np.array([
-            0,
-            -1,    # Auto-correlation: should be removed
-            0,
-            1,
-            0
-        ], dtype=np.int16)
         vis = np.array([
             [
-                [0.5 - 2.3j, 0.1 + 4.2j, 0.0 - 3j, 1.5 + 0j],
                 [0.5 - 2.3j, 0.1 + 4.2j, 0.0 - 3j, 1.5 + 0j],
                 [1.2 + 3.4j, 5.6 + 7.8j, 9.0 + 1.2j, 3.4 + 5.6j],
                 [1.5 + 1.3j, 1.1 + 2.7j, 1.0 - 2j, 2.5 + 1j],
                 [10.0, 10.0, 10.0, 10.0]
             ], [
-                [3.0 + 0j, 0.0 - 6j, 0.2 + 8.4j, 1.0 - 4.6j],
                 [3.0 + 0j, 0.0 - 6j, 0.2 + 8.4j, 1.0 - 4.6j],
                 [6.8 + 11.2j, 18.0 + 2.4j, 11.2 + 15.6j, 2.4 + 6.8j],
                 [3.0 + 2j, 2.0 - 4j, 2.2 + 5.4j, 3.0 + 2.6j],
@@ -118,13 +106,13 @@ class BaseTestVisibilityCollector:
             ]], dtype=np.complex64)
         if use_feed_angles:
             # TODO: use non-trivial feed angles and matrices
-            feed_angle1 = feed_angle2 = np.zeros(5, np.float32)
+            feed_angle1 = feed_angle2 = np.zeros(4, np.float32)
             mueller_stokes = mueller_circular = np.matrix(np.identity(4, np.complex64))
         else:
             feed_angle1 = feed_angle2 = mueller_circular = None
             mueller_stokes = np.matrix(np.identity(4, np.complex64))
         with closing(self.factory(self.image_parameters, self.grid_parameters, 64)) as collector:
-            collector.add(uvw, weights, baselines, vis,
+            collector.add(uvw, weights, vis,
                           feed_angle1, feed_angle2,
                           mueller_stokes, mueller_circular)
         self.check(collector, [


### PR DESCRIPTION
Previously, the preprocessing would sort by (channel, w_slice, baseline). Visibilities in a batch are already processed in channel-major order, so we can skip sorting by channel. We can also switch the sort order to (baseline, w_slice) with very little loss in compression efficiency; that allows sorting by baseline to be made the caller's problem, which is easy for katdal (just a transpose) and still quite cheap for an MS (requires an argsort but it is channel-independent). Finally, sorting by w_slice can be done in linear time with a bucket-sort, because we expect only a small number (dozens) of w slices.

The preprocessor had a feature where a baseline index could be set to a negative value to indicate an autocorrelation to skip, but it wasn't actually used (both loaders did their own filtering of autocorrelations) so it has been removed.

This all makes the preprocessing faster (twice as fast in a micro-benchmark, but in reality the HDF5 overheads will reduce that).