### PR TITLE
Do data loading in parallel with preprocessing 

### DIFF
--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -1,9 +1,11 @@
-import tempfile
-import os
+from abc import abstractmethod
 import atexit
+import concurrent.futures
+import contextlib
 import logging
 import math
-from abc import abstractmethod
+import os
+import tempfile
 from typing import List, Iterable
 
 import numpy as np
@@ -14,7 +16,7 @@ from . import (
     loader, loader_core, parameters, polarization, preprocess, clean, weight, sky_model,
     imaging, progress, beam, primary_beam, numba, arguments
 )
-from .profiling import profile_function
+from .profiling import profile, profile_function
 
 
 logger = logging.getLogger(__name__)
@@ -34,20 +36,41 @@ def preprocess_visibilities(dataset, args, start_channel, stop_channel,
     else:
         collector = preprocess.VisibilityCollectorMem(
             image_parameters, grid_parameters, args.vis_block)
-    try:
+
+    def reap():
+        nonlocal add_future
+        if add_future is not None:
+            with profile('concurrent.futures.result'):
+                bar_progress = add_future.result()
+            bar.goto(bar_progress)
+            add_future = None
+
+    with contextlib.ExitStack() as exit_stack:
+        exit_stack.callback(collector.close)
+        # We overload data loading with preprocessing by using a separate
+        # thread for preprocessing. To limit memory usage, we only allow
+        # one outstanding chunk at a time.
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        exit_stack.enter_context(executor)
+        add_future = None
         for chunk in loader.data_iter(dataset, args.vis_limit, args.vis_load,
                                       start_channel, stop_channel):
             if bar is None:
                 bar = progress.make_progressbar("Preprocessing vis", max=chunk['total'])
-            collector.add(
-                chunk['uvw'], chunk['weights'], chunk['vis'],
-                chunk.get('feed_angle1'), chunk.get('feed_angle2'),
-                *polarization_matrices)
-            bar.goto(chunk['progress'])
-    finally:
-        if bar is not None:
-            bar.finish()
-        collector.close()
+                exit_stack.callback(bar.finish)
+            reap()
+
+            @profile_function()
+            def add_chunk(chunk):
+                collector.add(
+                    chunk['uvw'], chunk['weights'], chunk['vis'],
+                    chunk.get('feed_angle1'), chunk.get('feed_angle2'),
+                    *polarization_matrices)
+                return chunk['progress']
+
+            add_future = executor.submit(add_chunk, chunk)
+        reap()
+
     logger.info("Compressed %d visibilities to %d (%.2f%%)",
                 collector.num_input, collector.num_output,
                 100.0 * collector.num_output / collector.num_input)

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -47,7 +47,7 @@ def preprocess_visibilities(dataset, args, start_channel, stop_channel,
 
     with contextlib.ExitStack() as exit_stack:
         exit_stack.callback(collector.close)
-        # We overload data loading with preprocessing by using a separate
+        # We overlap data loading with preprocessing by using a separate
         # thread for preprocessing. To limit memory usage, we only allow
         # one outstanding chunk at a time.
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)

--- a/katsdpimager/preprocess.cpp
+++ b/katsdpimager/preprocess.cpp
@@ -171,7 +171,7 @@ visibility_collector_base::visibility_collector_base(
     check_dimensions(config, -1);
     // Copy from py::array to vector. This makes it safe to use without the GIL.
     this->config.reserve(config.size());
-    for (std::size_t i = 0; i < config.size(); i++)
+    for (decltype(config.size()) i = 0; i < config.size(); i++)
         this->config.push_back(config.at(i));
 }
 


### PR DESCRIPTION
The preprocessing is offloaded to a separate thread, which drops the GIL
to allow parallel work. It ends up only making a small difference,
because the loading is slowed down (not sure if that's contention for
the GIL or for memory).