### PR TITLE
Use OpenMP to accelerate preprocessing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ extensions = [
         include_dirs=pybind11_include_dirs + list(eigen3.get('include_dirs', [])),
         depends=glob.glob('katsdpimager/*.h'),
         extra_compile_args=['-std=' + os.environ.get('KATSDPIMAGER_STD_CXX', 'c++1y'),
-                            '-g0', '-fvisibility=hidden'],
+                            '-g0', '-fvisibility=hidden', '-fopenmp'],
+        extra_link_args=['-fopenmp'],
         libraries=list(eigen3.get('libraries', []))
     )
 ]


### PR DESCRIPTION
For a test with katdal, this made preprocessing effectively free as it
overlapped entirely with data loading. It does, however, slow down the
data loading, presumably due to memory contention (it did not seem to
saturate the CPU cores).