### PR TITLE
Remove support for .h5 katdal datasets

### DIFF
--- a/doc/user.rst
+++ b/doc/user.rst
@@ -50,17 +50,18 @@ additional requirements as some C code will need to be compiled:
 
 File formats
 ============
-Two input formats are supported: `Measurement Sets`_ and KAT/MeerKAT
-data sets read by `katdal`_. Output is to `FITS`_ files. The input can contain
-multiple channels, but a separate FITS file is written for each channel.
+Two input formats are supported: `Measurement Sets`_ and MeerKAT data sets read
+by `katdal`_. Output is to `FITS`_ files. The input can contain multiple
+channels, but a separate FITS file is written for each channel.
 
 .. _Measurement sets: http://casa.nrao.edu/Memos/229.html
 .. _katdal: https://katdal.readthedocs.io/
 .. _FITS: http://fits.gsfc.nasa.gov/fits_documentation.html
 
 The input file format is detected by extension, so a Measurement Set *must*
-have the suffix ``.ms`` and a katdal data set must have the suffix ``.h5`` or
-``.rdb``.
+have the suffix ``.ms`` and a katdal data set must have the suffix ``.rdb``.
+The older ``.h5`` katdal formats are not supported; they need to be converted
+to Measurement Sets and calibrated.
 
 Command-line options
 ====================
@@ -147,12 +148,6 @@ Input selection options
 
    The katdal backend supports the following:
 
-   subarray=<INDEX>
-     Subarray index within the file, starting from 0 (defaults to first in
-     file).
-   spw=<INDEX>
-     Spectral window index within the file, starting from 0 (defaults to first
-     in file).
    target=<TARGET>
      Target to image. This can be either an index into the catalogue stored in
      the file (starting from 0) or a name. If not specified, it defaults to the

--- a/katsdpimager/test/test_loader_katdal.py
+++ b/katsdpimager/test/test_loader_katdal.py
@@ -377,7 +377,7 @@ class TestLoaderKatdal:
         self._test_data(options=['--rfi-mask=config'], channel_mask=mask)
 
     def test_match(self):
-        assert_true(LoaderKatdal.match('foo.h5'))
+        assert_false(LoaderKatdal.match('foo.h5'))
         assert_true(LoaderKatdal.match('foo.rdb'))
         assert_false(LoaderKatdal.match('foo.ms'))
         assert_true(LoaderKatdal.match('http://example.invalid/foo/bar.rdb?query=params#fragment'))


### PR DESCRIPTION
They wouldn't have worked anyway after #79, but more importantly, it
would never have been useful because no calibration would have been
applied.

This allows some simplification, because several code paths had to have
fallbacks for when v4 features are not available. Also remove the spw
and subarray command-line arguments since v4 only supports one of each.