### PR TITLE
Speed up computation of total flux

### DIFF
--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -192,7 +192,10 @@ def find_peak(image, pbeam, noise):
 @profile_function()
 def get_totals(image_parameters, image, restoring_beam):
     """Compute total flux density in each polarization."""
-    sums = np.nansum(image, axis=(1, 2), dtype=np.float64)   # Sum separately per polarization
+    # Using `where` is a faster version of np.nansum
+    # (see https://github.com/numpy/numpy/issues/12662).
+    sums = np.sum(image, axis=(1, 2), dtype=np.float64,
+                  where=~np.isnan(image))   # Sum separately per polarization
     # Area under the restoring beam. It is a Gaussian with peak of 1, and
     # hence the area under it is 2πσ_xσ_y. The Beam class holds FWHM (in
     # pixels) not standard deviations, hence the extra factor of 8*log 2.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
     'h5py',
     'katsdpsigproc',
     'katpoint',
-    'numpy>=1.16.0',
+    'numpy>=1.17.0',
     'progress>=1.5',
     'pycuda',
     'scikit-cuda',


### PR DESCRIPTION
numpy 1.17 provides a `where` option to np.sum which allows nansum to be
computed faster.