### PR TITLE
Track CLEAN components

### DIFF
--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -863,6 +863,9 @@ class Clean(accel.OperationSequence):
         peak_value : float
             The clean mode metric for the peak, or ``None`` if it was
             below the threshold and so no subtraction was done.
+        peak_pos : tuple[int]
+            (y, x) coordinates of the peak sample, or ``None`` if no
+            subtraction was done.
         """
         self.ensure_all_bound()
         self._find_peak()
@@ -874,10 +877,10 @@ class Clean(accel.OperationSequence):
             self.command_queue.finish()
         peak_value = peak_value_device.get_async(self.command_queue, self._peak_value_host)
         peak_pos = peak_pos_device.get_async(self.command_queue, self._peak_pos_host)
-        peak_pos = [int(x) for x in peak_pos]
+        peak_pos = tuple(int(x) for x in peak_pos)
         self.command_queue.finish()
         if peak_value[0] < threshold:
-            return None
+            return None, None
 
         self._subtract_psf(peak_pos, psf_patch)
         # Update the tiles
@@ -886,7 +889,7 @@ class Clean(accel.OperationSequence):
         y0 = peak_pos[0] - psf_patch[1] // 2
         y1 = y0 + psf_patch[1]
         self._update_tiles(x0, y0, x1, y1)
-        return peak_value[0]
+        return peak_value[0], peak_pos
 
 
 def psf_patch_host(psf, threshold, limit=None):
@@ -1061,7 +1064,7 @@ class CleanHost:
         peak_pos = self._tile_pos[peak_tile]
         peak_value = self._tile_max[peak_tile]
         if peak_value < threshold:
-            return None
+            return None, None
         (y0, x0, y1, x1) = self._subtract_psf(peak_pos[0], peak_pos[1], psf_patch)
         tile_y0 = max((y0 - self.border_pixels) // self.tile_size, 0)
         tile_x0 = max((x0 - self.border_pixels) // self.tile_size, 0)
@@ -1070,4 +1073,4 @@ class CleanHost:
         for y in range(tile_y0, tile_y1):
             for x in range(tile_x0, tile_x1):
                 self._update_tile(y, x)
-        return peak_value
+        return peak_value, tuple(int(x) for x in peak_pos)

--- a/katsdpimager/test/test_predict.py
+++ b/katsdpimager/test/test_predict.py
@@ -113,7 +113,9 @@ class TestPredict:
         image[:, 1024, 512] = [2.5, 1.5, 0.0]
         image[:, 0, 4095] = [4, 0, 0]
         image[:, 4095, 0] = [5, 1, 2]
-        lmn, flux = predict._extract_sky_image(self.image_parameters, self.grid_parameters, image)
+        coords = [(2048, 2048), (1024, 512), (0, 4095), (4095, 0)]
+        lmn, flux = predict._extract_sky_image(
+            self.image_parameters, self.grid_parameters, image, coords)
         assert_equal(lmn.shape, (4, 3))
         assert_equal(flux.shape, (4, 3))
         np.testing.assert_allclose(lmn[:, 0:2], [


### PR DESCRIPTION
Store a `set` of pixels that have been set in the model image, instead
of searching for them on each major cycle. This should speed things up a
little.