### PR TITLE
Some rework on FFT

### DIFF
--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -597,7 +597,8 @@ def process_channel(dataset, args, start_channel,
     if args.host:
         beam.convolve_beam(model, restoring_beam, model)
     else:
-        restore = beam.ConvolveBeamTemplate(queue, model.shape[1:], model.dtype).instantiate()
+        restore = beam.ConvolveBeamTemplate(
+            context, model.shape[1:], model.dtype).instantiate(queue)
         restore.beam = restoring_beam
         restore.ensure_all_bound()
         restore_image = restore.buffer('image')

--- a/katsdpimager/imaging.py
+++ b/katsdpimager/imaging.py
@@ -67,8 +67,7 @@ class Imaging(accel.OperationSequence):
         # It would be nice if there was a cleaner way to handle this; possibly
         # by deferring creation of the FFT plan until instantiation.
         padded_layer_shape = layer_shape = image_shape[1:]
-        fft_plan = template.grid_image.make_fft_plan(
-            command_queue, layer_shape, padded_layer_shape)
+        fft_plan = template.grid_image.make_fft_plan(layer_shape, padded_layer_shape)
 
         self._gridder = template.gridder.instantiate(
             command_queue,

--- a/katsdpimager/test/test_beam.py
+++ b/katsdpimager/test/test_beam.py
@@ -48,8 +48,8 @@ class TestConvolveBeam:
     @device_test
     @cuda_test
     def test_device(self, context, command_queue):
-        template = beam.ConvolveBeamTemplate(command_queue, self.model.shape[1:], self.model.dtype)
-        fn = template.instantiate()
+        template = beam.ConvolveBeamTemplate(context, self.model.shape[1:], self.model.dtype)
+        fn = template.instantiate(command_queue)
         fn.ensure_all_bound()
         for pol in range(self.model.shape[0]):
             fn.buffer('image').set(command_queue, self.model[pol])

--- a/katsdpimager/test/test_fft.py
+++ b/katsdpimager/test/test_fft.py
@@ -52,9 +52,10 @@ class TestFft:
     def test_forward(self, context, command_queue):
         rs = RandomState(1)
         template = fft.FftTemplate(
-            command_queue, 2, (3, 2, 16, 48), np.complex64, np.complex64,
+            context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
             (4, 5, 24, 64), (4, 5, 20, 48))
-        fn = template.instantiate(fft.FFT_FORWARD, allocator=accel.SVMAllocator(context))
+        fn = template.instantiate(command_queue, fft.FFT_FORWARD,
+                                  allocator=accel.SVMAllocator(context))
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')
@@ -67,8 +68,9 @@ class TestFft:
     def _test_r2c(self, context, command_queue, N, shape, padded_shape_src, padded_shape_dest):
         rs = np.random.RandomState(1)
         template = fft.FftTemplate(
-            command_queue, N, shape, np.float32, np.complex64, padded_shape_src, padded_shape_dest)
-        fn = template.instantiate(fft.FFT_FORWARD, allocator=accel.SVMAllocator(context))
+            context, N, shape, np.float32, np.complex64, padded_shape_src, padded_shape_dest)
+        fn = template.instantiate(command_queue, fft.FFT_FORWARD,
+                                  allocator=accel.SVMAllocator(context))
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')
@@ -81,8 +83,9 @@ class TestFft:
     def _test_c2r(self, context, command_queue, N, shape, padded_shape_src, padded_shape_dest):
         rs = np.random.RandomState(1)
         template = fft.FftTemplate(
-            command_queue, N, shape, np.complex64, np.float32, padded_shape_src, padded_shape_dest)
-        fn = template.instantiate(fft.FFT_INVERSE, allocator=accel.SVMAllocator(context))
+            context, N, shape, np.complex64, np.float32, padded_shape_src, padded_shape_dest)
+        fn = template.instantiate(command_queue, fft.FFT_INVERSE,
+                                  allocator=accel.SVMAllocator(context))
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')
@@ -118,9 +121,10 @@ class TestFft:
     def test_inverse(self, context, command_queue):
         rs = RandomState(1)
         template = fft.FftTemplate(
-            command_queue, 2, (3, 2, 16, 48), np.complex64, np.complex64,
+            context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
             (4, 5, 24, 64), (4, 5, 20, 48))
-        fn = template.instantiate(fft.FFT_INVERSE, allocator=accel.SVMAllocator(context))
+        fn = template.instantiate(command_queue, fft.FFT_INVERSE,
+                                  allocator=accel.SVMAllocator(context))
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')


### PR DESCRIPTION
- Move command_queue from template to operation.
- Explicitly expose the work area as a slot.
- Lock the template when enqueuing the operation. It's now safe to have
  multiple operations made from the same template and call them
  concurrently (previously even doing it serially was unsafe due to
  clobbering the single work area).
- Check the version of CUFFT before enabling the workaround for CUFFT
  7.0, so that it will not slow down more modern versions.