### PR TITLE
Remove ability to pad FFTs along batch dimensions

### DIFF
--- a/katsdpimager/test/test_fft.py
+++ b/katsdpimager/test/test_fft.py
@@ -53,7 +53,7 @@ class TestFft:
         rs = RandomState(1)
         template = fft.FftTemplate(
             context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
-            (4, 5, 24, 64), (4, 5, 20, 48))
+            (3, 2, 24, 64), (3, 2, 20, 48))
         fn = template.instantiate(command_queue, fft.FFT_FORWARD,
                                   allocator=accel.SVMAllocator(context))
         fn.ensure_all_bound()
@@ -99,22 +99,22 @@ class TestFft:
     @device_test
     @cuda_test
     def test_r2c_even(self, context, command_queue):
-        self._test_r2c(context, command_queue, 2, (3, 2, 16, 48), (4, 5, 24, 64), (4, 5, 20, 27))
+        self._test_r2c(context, command_queue, 2, (3, 2, 16, 48), (3, 2, 24, 64), (3, 2, 20, 27))
 
     @device_test
     @cuda_test
     def test_r2c_odd(self, context, command_queue):
-        self._test_r2c(context, command_queue, 2, (3, 2, 15, 47), (4, 5, 23, 63), (4, 5, 17, 24))
+        self._test_r2c(context, command_queue, 2, (3, 2, 15, 47), (3, 2, 23, 63), (3, 2, 17, 24))
 
     @device_test
     @cuda_test
     def test_c2r_even(self, context, command_queue):
-        self._test_c2r(context, command_queue, 2, (3, 2, 16, 48), (4, 5, 20, 27), (4, 5, 24, 64))
+        self._test_c2r(context, command_queue, 2, (3, 2, 16, 48), (3, 2, 20, 27), (3, 2, 24, 64))
 
     @device_test
     @cuda_test
     def test_c2r_odd(self, context, command_queue):
-        self._test_c2r(context, command_queue, 2, (3, 2, 15, 47), (4, 5, 17, 24), (4, 5, 23, 63))
+        self._test_c2r(context, command_queue, 2, (3, 2, 15, 47), (3, 2, 17, 24), (3, 2, 23, 63))
 
     @device_test
     @cuda_test
@@ -122,7 +122,7 @@ class TestFft:
         rs = RandomState(1)
         template = fft.FftTemplate(
             context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
-            (4, 5, 24, 64), (4, 5, 20, 48))
+            (3, 2, 24, 64), (3, 2, 20, 48))
         fn = template.instantiate(command_queue, fft.FFT_INVERSE,
                                   allocator=accel.SVMAllocator(context))
         fn.ensure_all_bound()


### PR DESCRIPTION
This was never actually used (as far as I know), but was added at the
time because it seemed trivial to support. However, it was failing after
updating some code. CUFFT does joint processing on several batches and then disentangles
them. When some of those batches contain uninitialised padding data,
this can lead to problem if the uninitialised data is very large
compared to the real data (or even Inf/NaN).