### PR TITLE
Update docstring types to use katsdpsigproc.abc abstract types

### DIFF
--- a/doc/macros.rst
+++ b/doc/macros.rst
@@ -1,2 +1,0 @@
-.. |CommandQueue| replace:: :class:`katsdpsigproc.cuda.CommandQueue` or :class:`katsdpsigproc.opencl.CommandQueue`
-.. |Context| replace:: :class:`katsdpsigproc.cuda.Context` or :class:`katsdpsigproc.opencl.Context`

--- a/katsdpimager/beam.py
+++ b/katsdpimager/beam.py
@@ -32,8 +32,6 @@ and its square root is
 :math:`M = R\left(\begin{smallmatrix}\sigma_1 & 0\\0 & \sigma_2\end{smallmatrix}\right)R^T`.
 
 .. _Mathworld: http://mathworld.wolfram.com/FourierTransformGaussian.html
-
-.. include:: macros.rst
 """
 
 import math
@@ -210,7 +208,7 @@ class FourierBeamTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`numpy.float32`, `numpy.float64`}
         Real data type
@@ -253,12 +251,12 @@ class FourierBeam(accel.Operation):
     ----------
     template : :class:`FourierBeamTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     image_shape : tuple
         (height, width) of the image. Note that the buffer on which this operation works
         will have shape (height, width // 2 + 1).
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, image_shape, allocator=None):

--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -11,8 +11,6 @@ The GPU implementation currently round-trips to the CPU on each minor cycle.
 It could be done entirely on the GPU, but round-tripping will make it easier
 to put in a threshold later. It should still be possible to do batches of
 minor cycles if the launch overheads become an issue.
-
-.. include:: macros.rst
 """
 
 import math
@@ -42,7 +40,7 @@ class PsfPatchTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Precision of image
@@ -94,11 +92,11 @@ class PsfPatch(accel.Operation):
     ----------
     template : :class:`PsfPatchTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of ints
         Shape for the PSF
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
 
@@ -215,7 +213,7 @@ class NoiseEstTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Image precision
@@ -263,13 +261,13 @@ class NoiseEst(accel.Operation):
     ----------
     template : :class:`NoiseEstTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     image_shape : tuple of ints
         Shape for the dirty image
     border : float
         Distance from each edge of dirty image to ignore in ranking, as fraction of image size
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
 
@@ -365,7 +363,7 @@ class _UpdateTilesTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Precision of image
@@ -418,13 +416,13 @@ class _UpdateTiles(accel.Operation):
     ----------
     template : :class:`_UpdateTilesTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     image_shape : tuple of ints
         Shape for the dirty image
     border : float
         Distance from each edge of dirty image where tiles start, as a fraction of image size
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
 
@@ -491,7 +489,7 @@ class _FindPeakTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Image precision
@@ -542,13 +540,13 @@ class _FindPeak(accel.Operation):
     ----------
     template : :class:`_FindPeakTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     image_shape : tuple of int
         Shape of the dirty image, as (num_polarizations, height, width)
     tile_shape : tuple of int
         Shape of the tile array, as (height, width)
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, image_shape, tile_shape, allocator=None):
@@ -599,7 +597,7 @@ class _SubtractPsfTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Image precision
@@ -647,7 +645,7 @@ class _SubtractPsf(accel.Operation):
     ----------
     template : :class:`_SubtractPsfTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     loop_gain : float
         Scale factor for subtraction. The PSF is scaled by both `loop_gain` and
@@ -656,7 +654,7 @@ class _SubtractPsf(accel.Operation):
         Shape for the dirty and model images, as (num_polarizations, height, width)
     psf_shape : tuple of int
         Shape for the point spread function, as (num_polarizations, height, width)
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -737,7 +735,7 @@ class CleanTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     clean_parameters : :class:`katsdpimager.parameters.CleanParameters`
         Command-line parameters for CLEAN
@@ -790,11 +788,11 @@ class Clean(accel.OperationSequence):
     ----------
     template : :class:`_UpdateTilesTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     image_parameters : :class:`katsdpimager.parameters.ImageParameters`
         Command-line parameters with image properties
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises

--- a/katsdpimager/fft.py
+++ b/katsdpimager/fft.py
@@ -1,7 +1,4 @@
-"""Utilities to wrap skcuda.fft for imaging purposes.
-
-.. include:: macros.rst
-"""
+"""Utilities to wrap skcuda.fft for imaging purposes."""
 
 import threading
 
@@ -65,7 +62,7 @@ class FftshiftTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : numpy dtype
         Data type being stored
@@ -103,11 +100,11 @@ class Fftshift(accel.Operation):
     ----------
     template : :class:`FftshiftTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of int
         Shape of the data.
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -250,7 +247,7 @@ class Fft(accel.Operation):
         Operation template
     mode : {:data:`FFT_FORWARD`, :data:`FFT_INVERSE`}
         FFT direction
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, mode, allocator=None):

--- a/katsdpimager/grid.py
+++ b/katsdpimager/grid.py
@@ -113,8 +113,6 @@ devices, and even then may limit the block size.
    gridding radio-telescope data on GPUs. In *Proceedings of the 26th ACM International
    Conference on Supercomputing (ICS '12)*, 321-330.
    http://www.astron.nl/~romein/papers/ICS-12/gridding.pdf
-
-.. include:: macros.rst
 """
 
 import math
@@ -512,7 +510,7 @@ def _autotune_arrays(command_queue, oversample, real_dtype, num_polarizations, b
 
     Parameters
     ----------
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for zeroing the arrays
     oversample : int
         Grid oversampling
@@ -677,13 +675,13 @@ class VisOperation(accel.Operation):
 
     Parameters
     ----------
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     num_polarizations : int
         Size of vis buffer on polarization dimension
     max_vis : int
         Number of visibilities that can be supported per kernel invocation
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, command_queue, num_polarizations, max_vis, allocator=None):
@@ -749,7 +747,7 @@ class GridDegrid(VisOperation):
     ----------
     template : :class:`GridderTemplate` or :class:`DegridderTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     array_parameters : :class:`~katsdpimager.parameters.ArrayParameters`
         Array parameters
@@ -759,7 +757,7 @@ class GridDegrid(VisOperation):
         Channel-specific gridding parameters
     max_vis : int
         Number of visibilities that can be supported per kernel invocation
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -821,9 +819,9 @@ class Gridder(GridDegrid):
 
         Parameters
         ----------
-        command_queue : |CommandQueue|
+        command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
             Command queue for the operation
-        kernel : :class:`katsdpsigproc.cuda.Kernel` or :class:`katsdpsigproc.opencl.Kernel`
+        kernel : :class:`katsdpsigproc.abc.AbstractKernel`
             Compiled kernel to run
         wgs_x,wgs_y,tile_x,tile_y,bin_size : int
             Tuning parameters (see :class:`GridTemplate`)

--- a/katsdpimager/image.py
+++ b/katsdpimager/image.py
@@ -1,8 +1,6 @@
 """Kernels for image-domain processing
 
 It also handles conversion between visibility and image planes.
-
-.. include:: macros.rst
 """
 
 import numpy as np
@@ -66,7 +64,7 @@ class _LayerImageTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     real_dtype : {`np.float32`, `np.float64`}
         Image type
@@ -105,7 +103,7 @@ class _LayerImage(accel.Operation):
     ----------
     template : :class:`_LayerImageTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of int
         Shape of the image data (polarizations, height, width) - must be square
@@ -115,7 +113,7 @@ class _LayerImage(accel.Operation):
         Bias from scaled pixel coordinates to l/m coordinates
     kernel_name : str
         Name of the kernel function
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -188,7 +186,7 @@ class LayerToImageTemplate(_LayerImageTemplate):
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     real_dtype : {`np.float32`, `np.float64`}
         Image type
@@ -211,7 +209,7 @@ class LayerToImage(_LayerImage):
     ----------
     template : :class:`LayerToImageTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of int
         Shape of the data (must be square)
@@ -219,7 +217,7 @@ class LayerToImage(_LayerImage):
         Scale factor from pixel coordinates to l/m coordinates
     lm_bias : float
         Bias from scaled pixel coordinates to l/m coordinates
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -237,7 +235,7 @@ class ImageToLayerTemplate(_LayerImageTemplate):
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     real_dtype : {`np.float32`, `np.float64`}
         Image type
@@ -260,7 +258,7 @@ class ImageToLayer(_LayerImage):
     ----------
     template : :class:`ImageToLayerTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of int
         Shape of the image as (polarizations, height, width) - must be square
@@ -268,7 +266,7 @@ class ImageToLayer(_LayerImage):
         Scale factor from pixel coordinates to l/m coordinates
     lm_bias : float
         Bias from scaled pixel coordinates to l/m coordinates
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -286,7 +284,7 @@ class ScaleTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Image precision
@@ -329,11 +327,11 @@ class Scale(accel.Operation):
     ----------
     template : :class:`ScaleTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of int
         Shape of the data.
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, shape, allocator=None):
@@ -374,7 +372,7 @@ class ApplyPrimaryBeamTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     dtype : {`np.float32`, `np.float64`}
         Image precision
@@ -419,7 +417,7 @@ class ApplyPrimaryBeam(accel.Operation):
     ----------
     template : :class:`ApplyPrimaryBeamTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     shape : tuple of int
         Shape of the data.
@@ -428,7 +426,7 @@ class ApplyPrimaryBeam(accel.Operation):
         `replacement` instead of divided by the primary beam power
     replacement : float
         Substitute value for regions where beam power is below `threshold`
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
 
@@ -481,7 +479,7 @@ class GridImageTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     real_dtype : {`np.float32`, `np.float64`}
         Precision
@@ -532,7 +530,7 @@ class GridToImage(accel.OperationSequence):
         See :class:`LayerToImage`
     fft_plan : :class:`fft.FftTemplate`
         See :meth:`GridImageTemplate.make_fft_plan`
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, shape_grid,
@@ -599,7 +597,7 @@ class ImageToGrid(accel.OperationSequence):
         See :class:`ImageToLayer`
     fft_plan : :class:`fft.FftTemplate`
         See :meth:`GridImageTemplate.make_fft_plan`
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, shape_grid,

--- a/katsdpimager/predict.py
+++ b/katsdpimager/predict.py
@@ -10,8 +10,6 @@ not supported at all.
 
 The visibilities are assumed to have already been passed through the
 :mod:`preprocess` module, and hence UVW coordinates will be quantised.
-
-.. include:: macros.rst
 """
 
 import logging
@@ -157,7 +155,7 @@ class PredictTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     real_dtype : {np.float32, np.float64}
         Data type for internal accumulation of values. This does not affect
@@ -273,7 +271,7 @@ class Predict(grid.VisOperation):
     ----------
     template : :class:`PredictTemplate`
         The template for the operation
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         The command queue for the operation
     image_parameters : :class:`~.ImageParameters`
         Parameters that determine the UVW quantisation
@@ -283,7 +281,7 @@ class Predict(grid.VisOperation):
         Maximum number of visibilities this instance can support
     max_sources : int
         Maximum number of sources this instance can support
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, image_parameters, grid_parameters,

--- a/katsdpimager/weight.py
+++ b/katsdpimager/weight.py
@@ -41,8 +41,6 @@ different beam shapes for the different polarizations.
 .. [Bri95] Briggs, D. S. 1995. High fidelity deconvolution of moderately
    resolved sources. PhD Thesis, The New Mexico Institute of Mining and Technology.
    http://www.aoc.nrao.edu/dissertations/dbriggs/
-
-.. include:: macros.rst
 """
 
 import enum
@@ -65,7 +63,7 @@ class GridWeightsTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     num_polarizations : int
         Number of polarizations to grid
@@ -110,13 +108,13 @@ class GridWeights(accel.Operation):
     ----------
     template : :class:`GridWeightsTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     grid_shape : tuple of ints
         Shape for the grid, (polarizations, height, width)
     max_vis : int
         Maximum number of weights that can be gridded in one pass
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Raises
@@ -190,7 +188,7 @@ class DensityWeightsTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     num_polarizations : int
         Number of polarizations to grid
@@ -237,11 +235,11 @@ class DensityWeights(accel.Operation):
     ----------
     template : :class:`DensityWeightsTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     grid_shape : tuple of ints
         Shape for the grid, (polarizations, height, width)
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, grid_shape, allocator=None):
@@ -305,7 +303,7 @@ class MeanWeightTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     tuning : dict, optional
         Tuning parameters (unused)
@@ -339,11 +337,11 @@ class MeanWeight(accel.Operation):
     ----------
     template : :class:`MeanWeightTemplate`
         Operation template
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     grid_shape : tuple of ints
         Shape for the grid, (polarizations, height, width)
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, grid_shape, allocator=None):
@@ -387,7 +385,7 @@ class WeightsTemplate:
 
     Parameters
     ----------
-    context : |Context|
+    context : :class:`katsdpsigproc.abc.AbstractContext`
         Context for which kernels will be compiled
     weight_type : :class:`WeightType`
         Weighting method
@@ -448,13 +446,13 @@ class Weights(accel.OperationSequence):
 
     Parameters
     ----------
-    command_queue : |CommandQueue|
+    command_queue : :class:`katsdpsigproc.abc.AbstractCommandQueue`
         Command queue for the operation
     grid_shape : tuple of ints
         Shape for the grid, (polarizations, height, width)
     max_vis : int
         Maximum number of weights that can be gridded in one pass
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator : :class:`~katsdpsigproc.accel.AbstractAllocator`, optional
         Allocator used to allocate unbound slots
 
     Attributes


### PR DESCRIPTION
This makes the docstrings shorter, and also removes references to
SVMAllocator which may no longer be appropriate.