### PR TITLE
Fix a bug-in-waiting in clean

### DIFF
--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -875,8 +875,8 @@ class Clean(accel.OperationSequence):
             self.command_queue.finish()
         peak_value = peak_value_device.get_async(self.command_queue, self._peak_value_host)
         peak_pos = peak_pos_device.get_async(self.command_queue, self._peak_pos_host)
-        peak_pos = tuple(int(x) for x in peak_pos)
         self.command_queue.finish()
+        peak_pos = tuple(int(x) for x in peak_pos)
         if peak_value[0] < threshold:
             return None, None
 


### PR DESCRIPTION
A value read asynchronously was being used before blocking on the
transfer completing. It isn't currently a bug because with unified
memory/SVM, get_async isn't actually async, but it will become a bug
once I strip out unified memory.