### PR TITLE
Remove use of SVM

### DIFF
--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -155,8 +155,6 @@ class PsfPatch(accel.Operation):
                 global_size=(wg_x * self.template.wgsx, wg_y * self.template.wgsy),
                 local_size=(self.template.wgsx, self.template.wgsy)
             )
-        if isinstance(bound, accel.SVMArray):
-            self.command_queue.finish()
         bound.get(self.command_queue, self._bound_host)
         # Turn distances from the centre into a symmetric bounding box size.
         box = 2 * np.max(self._bound_host[: wg_x * wg_y], axis=0) + 1
@@ -344,8 +342,6 @@ class NoiseEst(accel.Operation):
                     global_size=(self._num_tiles_x * self.template.wgsx,
                                  self._num_tiles_y * self.template.wgsy),
                     local_size=(self.template.wgsx, self.template.wgsy))
-            if isinstance(rank, accel.SVMArray):
-                self.command_queue.finish()
             rank.get(self.command_queue, rank_host)
             cur_rank = rank_host.sum()
             if cur_rank < median_rank:
@@ -876,9 +872,6 @@ class Clean(accel.OperationSequence):
         peak_value_device = self.buffer('peak_value')
         peak_pos_device = self.buffer('peak_pos')
         peak_pixel_device = self.buffer('peak_pixel')
-        if (isinstance(peak_value_device, accel.SVMArray)
-                or isinstance(peak_pos_device, accel.SVMArray)):
-            self.command_queue.finish()
         peak_value = peak_value_device.get_async(self.command_queue, self._peak_value_host)
         peak_pos = peak_pos_device.get_async(self.command_queue, self._peak_pos_host)
         peak_pixel = peak_pixel_device.get_async(self.command_queue, self._peak_pixel_host)

--- a/katsdpimager/clean.py
+++ b/katsdpimager/clean.py
@@ -875,7 +875,7 @@ class Clean(accel.OperationSequence):
         peak_value = peak_value_device.get_async(self.command_queue, self._peak_value_host)
         peak_pos = peak_pos_device.get_async(self.command_queue, self._peak_pos_host)
         peak_pixel = peak_pixel_device.get_async(self.command_queue, self._peak_pixel_host)
-        self.command_queue.finish()
+        self.command_queue.finish()   # Wait for all the above gets at once
         if peak_value[0] < threshold:
             return None, None, None
         peak_pos = tuple(int(x) for x in peak_pos)

--- a/katsdpimager/fft.py
+++ b/katsdpimager/fft.py
@@ -17,38 +17,13 @@ FFT_FORWARD = 0
 FFT_INVERSE = 1
 
 
-class _Gpudata:
-    """Adapter to allow skcuda.fft to work with managed memory
-    allocations. Add it as a `gpudata` member on an arbitrary object, to allow
-    that object to be passed instead of a :py:class`pycuda.gpuarray.GPUArray`.
-    """
-    def __init__(self, array):
-        # .buffer gives the ndarray created by PyCUDA, and .base the ManagedAllocation
-        self._allocation = array.buffer.base
-
-    def __int__(self):
-        return self._allocation.get_device_pointer()
-
-    def __eq__(self, other):
-        return int(self) == int(other)
-
-    def __ne__(self, other):
-        return int(self) != int(other)
-
-
 class _GpudataWrapper:
-    """Forwarding wrapper around a :py:class:`katsdpsigproc.accel.SVMArray` or
-    :py:class:`katsdpsigproc.accel.DeviceArray` that allows it to be passed
-    to skcuda.fft.
+    """Forwarding wrapper around a :py:class:`katsdpsigproc.accel.DeviceArray`
+    that allows it to be passed to skcuda.fft.
     """
     def __init__(self, wrapped):
         self._wrapped = wrapped
-        try:
-            # Handle DeviceArray case
-            self.gpudata = wrapped.buffer.gpudata
-        except AttributeError:
-            # SVMArray case
-            self.gpudata = _Gpudata(wrapped)
+        self.gpudata = wrapped.buffer.gpudata
 
     def __getattr__(self, attr):
         return getattr(self._wrapped, attr)

--- a/katsdpimager/fft.py
+++ b/katsdpimager/fft.py
@@ -17,18 +17,6 @@ FFT_FORWARD = 0
 FFT_INVERSE = 1
 
 
-class _GpudataWrapper:
-    """Forwarding wrapper around a :py:class:`katsdpsigproc.accel.DeviceArray`
-    that allows it to be passed to skcuda.fft.
-    """
-    def __init__(self, wrapped):
-        self._wrapped = wrapped
-        self.gpudata = wrapped.buffer.gpudata
-
-    def __getattr__(self, attr):
-        return getattr(self._wrapped, attr)
-
-
 class FftshiftTemplate:
     """Operation template for the equivalent of :py:meth:`np.fft.fftshift` on
     the device, in-place. The last two dimensions are shifted, and these
@@ -255,14 +243,12 @@ class Fft(accel.Operation):
         with context, self.template.lock:
             skcuda.cufft.cufftSetStream(self.template.plan.handle,
                                         self.command_queue._pycuda_stream.handle)
-            self.template.plan.set_work_area(_GpudataWrapper(work_area_buffer))
+            self.template.plan.set_work_area(work_area_buffer.buffer)
             if self.mode == FFT_FORWARD:
                 with profile_device(self.command_queue, 'fft'):
-                    skcuda.fft.fft(_GpudataWrapper(src_buffer), _GpudataWrapper(dest_buffer),
-                                   self.template.plan)
+                    skcuda.fft.fft(src_buffer.buffer, dest_buffer.buffer, self.template.plan)
             else:
                 with profile_device(self.command_queue, 'ifft'):
-                    skcuda.fft.ifft(_GpudataWrapper(src_buffer), _GpudataWrapper(dest_buffer),
-                                    self.template.plan)
+                    skcuda.fft.ifft(src_buffer.buffer, dest_buffer.buffer, self.template.plan)
             if self.template.needs_synchronize_workaround:
                 context._pycuda_context.synchronize()

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -494,7 +494,8 @@ def process_channel(dataset, args, start_channel,
         imager = imager_template.instantiate(
             queue, image_p, grid_p, args.vis_block, n_sources, args.major, allocator)
         device_allocator = accel.DeviceAllocator(context)
-        for name in ['vis', 'weights', 'uv', 'w_plane']:
+        for name in ['vis', 'weights', 'uv', 'w_plane',
+                     'layer', 'tile_max', 'tile_pos', 'peak_pixel']:
             if name in imager.slots:
                 imager.slots[name].allocate(device_allocator)
         imager.ensure_all_bound()

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -493,6 +493,10 @@ def process_channel(dataset, args, start_channel,
         n_sources = len(subtract_model) if subtract_model else 0
         imager = imager_template.instantiate(
             queue, image_p, grid_p, args.vis_block, n_sources, args.major, allocator)
+        device_allocator = accel.DeviceAllocator(context)
+        for name in ['vis', 'weights', 'uv', 'w_plane']:
+            if name in imager.slots:
+                imager.slots[name].allocate(device_allocator)
         imager.ensure_all_bound()
     psf = imager.buffer('psf')
     dirty = imager.buffer('dirty')

--- a/katsdpimager/frontend.py
+++ b/katsdpimager/frontend.py
@@ -99,7 +99,6 @@ def make_weights(queue, reader, rel_channel, imager, weight_type, vis_block, wei
         noise, normalized_noise = imager.finalize_weights()
         if noise is not None and weight_scale is not None:
             noise *= weight_scale
-        queue.finish()
     if noise is not None:
         logger.info('Thermal RMS noise (from weights): %g', noise)
     logger.info('Normalized thermal RMS noise: %g', normalized_noise)
@@ -137,11 +136,9 @@ def make_dirty(queue, reader, rel_channel, name, field, imager, mid_w, vis_block
                     imager.predict(mid_w[w_slice])
                 imager.grid()
                 bar.next(len(chunk))
-            queue.finish()
 
         with progress.step('IFFT {}'.format(label)):
             imager.grid_to_image(mid_w[w_slice])
-            queue.finish()
 
 
 @profile_function()
@@ -585,7 +582,6 @@ def process_channel(dataset, args, start_channel,
         if i == args.major - 1:
             # Update the noise estimate for output stats
             noise = imager.noise_est()
-        queue.finish()
 
     # Scale by primary beam
     model = imager.buffer('model')

--- a/katsdpimager/grid.py
+++ b/katsdpimager/grid.py
@@ -434,19 +434,15 @@ class ConvolutionKernelDevice(ConvolutionKernel):
              grid_parameters.fixed.oversample,
              grid_parameters.fixed.kernel_width + 2 * pad),
             np.complex64)
-        if isinstance(out, accel.SVMArray):
-            host = out
-        else:
-            host = out.empty_like()
+        host = out.empty_like()
         host.fill(0)
         super().__init__(
             image_parameters,
             grid_parameters,
             host[:, :, pad:grid_parameters.fixed.kernel_width + pad]
         )
-        if not isinstance(out, accel.SVMArray):
-            queue = context.create_command_queue()
-            out.set(queue, host)
+        queue = context.create_command_queue()   # TODO: pass one in?
+        out.set(queue, host)
         self.padded_data = out
         self.pad = pad
 

--- a/katsdpimager/imaging.py
+++ b/katsdpimager/imaging.py
@@ -341,6 +341,20 @@ class Imaging(accel.OperationSequence):
                 self._model_components[peak_pos] = model_pixel
         return peak_value
 
+    @profile_function(labels=['name'])
+    def get_buffer(self, name):
+        """Get the contents of a buffer as a numpy array."""
+        return self.buffer(name).get(self.command_queue)
+
+    @profile_function(labels=['name'])
+    def set_buffer(self, name, data):
+        """Copy a numpy array to a buffer (blocking).
+
+        Because this is blocking, it is not considered a high performance
+        path. It exists to simplify compatibility with :class:`ImagingHost`.
+        """
+        self.buffer(name).set(self.command_queue, data)
+
 
 class ImagingHost:
     """Host-only equivalent to :class:`Imaging`."""
@@ -390,6 +404,12 @@ class ImagingHost:
 
     def buffer(self, name):
         return self._buffer[name]
+
+    def get_buffer(self, name):
+        return self._buffer[name]
+
+    def set_buffer(self, name, data):
+        self._buffer[name][()] = data
 
     @property
     def num_vis(self):

--- a/katsdpimager/imaging.py
+++ b/katsdpimager/imaging.py
@@ -100,14 +100,14 @@ class Imaging(accel.OperationSequence):
             command_queue, image_shape, 0.0, np.nan, allocator)
 
         # TODO: handle taper1d/untaper1d as standard slots
-        taper1d = accel.SVMArray(
+        taper1d = accel.DeviceArray(
             template.context,
             (image_parameters.pixels,),
             image_parameters.fixed.real_dtype)
         self._gridder.convolve_kernel.taper(image_parameters.pixels, taper1d)
         self._grid_to_image.bind(kernel1d=taper1d)
         if grid_parameters.fixed.degrid:
-            untaper1d = accel.SVMArray(
+            untaper1d = accel.DeviceArray(
                 template.context,
                 (image_parameters.pixels,),
                 image_parameters.fixed.real_dtype)

--- a/katsdpimager/imaging.py
+++ b/katsdpimager/imaging.py
@@ -333,9 +333,6 @@ class Imaging(accel.OperationSequence):
     def model_to_predict(self):
         if self.template.fixed_grid_parameters.degrid:
             raise RuntimeError('Can only use model_to_predict with direct prediction')
-        # Ensure that the previous call has completed (since it copies data to the
-        # GPU asynchronously). TODO: can probably get rid of this later.
-        self._predict.command_queue.finish()
         self._predict.set_sky_image(self._model_components)
 
     @profile_function()

--- a/katsdpimager/predict.py
+++ b/katsdpimager/predict.py
@@ -193,12 +193,20 @@ class PredictTemplate:
         # Need at least as many sources as the workgroup size to achieve full
         # throughput.
         num_sources = 1024
-        vis = accel.SVMArray(context, (num_vis, num_polarizations), dtype=np.complex64)
-        uv = accel.SVMArray(context, (num_vis, 4), dtype=np.int16)
-        w_plane = accel.SVMArray(context, (num_vis,), dtype=np.int16)
-        weights = accel.SVMArray(context, (num_vis, num_polarizations), dtype=np.float32)
-        lmn = accel.SVMArray(context, (num_sources, 3), dtype=np.float32)
-        flux = accel.SVMArray(context, (num_sources, num_polarizations), dtype=np.float32)
+        vis = accel.DeviceArray(context, (num_vis, num_polarizations), dtype=np.complex64)
+        uv = accel.DeviceArray(context, (num_vis, 4), dtype=np.int16)
+        w_plane = accel.DeviceArray(context, (num_vis,), dtype=np.int16)
+        weights = accel.DeviceArray(context, (num_vis, num_polarizations), dtype=np.float32)
+        lmn = accel.DeviceArray(context, (num_sources, 3), dtype=np.float32)
+        flux = accel.DeviceArray(context, (num_sources, num_polarizations), dtype=np.float32)
+        # The values don't really matter, but we want to avoid non-finites
+        # which would skew performance.
+        vis.zero(queue)
+        uv.zero(queue)
+        w_plane.zero(queue)
+        weights.zero(queue)
+        lmn.zero(queue)
+        flux.zero(queue)
 
         # The values don't make any difference to auto-tuning; they just affect
         # scale factors that have no impact on control flow.
@@ -263,8 +271,6 @@ class Predict(grid.VisOperation):
         The statistical weights associated with the visibilities. The input
         visibilities are assumed to be pre-weighted, and the predicted
         visibility is scaled by the weight before subtraction.
-
-    These slots must all be backed by SVM-allocated memory.
 
     Parameters
     ----------

--- a/katsdpimager/predict.py
+++ b/katsdpimager/predict.py
@@ -255,7 +255,7 @@ class Predict(grid.VisOperation):
     Before using a constructed instance, it's necessary to first
 
     1. Configure the visibilities, by setting :attr:`num_vis` and
-       calling :meth:`set_coordinates`, :meth:`set_vis` and :meth:`set_w`.
+       :meth:`set_w` and populating the visibility-related buffers.
     2. Configure the sources, by calling :meth:`set_sky_model` or
        :meth:`set_sky_image`.
 
@@ -312,8 +312,6 @@ class Predict(grid.VisOperation):
             (max_sources, 3), np.float32, context=command_queue.context)
         self._host_flux = accel.HostArray(
             (max_sources, template.num_polarizations), np.float32, context=command_queue.context)
-        self._host_weights = accel.HostArray(
-            (max_vis, template.num_polarizations), np.float32, context=command_queue.context)
 
     def _copy_lmn_flux(self):
         self.buffer('lmn').set_region(
@@ -370,20 +368,6 @@ class Predict(grid.VisOperation):
     @property
     def num_sources(self):
         return self._num_sources
-
-    def set_weights(self, weights):
-        """Set statistical weights on visibilities.
-
-        Before calling, set :attr:`num_vis`.
-        """
-        N = self.num_vis
-        if len(weights) != N:
-            raise ValueError('Lengths do not match')
-        self._host_weights[:N] = weights
-        self.buffer('weights').set_region(
-            self.command_queue, self._host_weights,
-            np.s_[:N], np.s_[:N],
-            blocking=False)
 
     def set_w(self, w):
         """Set the W slice.

--- a/katsdpimager/test/test_grid.py
+++ b/katsdpimager/test/test_grid.py
@@ -92,7 +92,7 @@ class BaseTest:
         max_vis = 1280
         n_vis = len(self.w_plane)
         rs = RandomState(seed=2)
-        vis = rs.complex_uniform(-1, 1, size=(n_vis, 4)).astype(np.complex128)
+        vis = rs.complex_uniform(-1, 1, size=(n_vis, 4)).astype(np.complex64)
         actual = callback(max_vis, vis)
         expected = np.zeros_like(actual)
         pixels = actual.shape[-1]
@@ -118,8 +118,8 @@ class BaseTest:
         shape = (4, pixels, pixels)
         rs = RandomState(seed=2)
         grid_data = rs.complex_uniform(-1, 1, size=shape).astype(np.complex128)
-        vis = rs.complex_uniform(-1, 1, size=(n_vis, 4)).astype(np.complex128)
-        weights = rs.uniform(0.5, 1.5, size=(n_vis, 4)).astype(np.float64)
+        vis = rs.complex_uniform(-1, 1, size=(n_vis, 4)).astype(np.complex64)
+        weights = rs.uniform(0.5, 1.5, size=(n_vis, 4)).astype(np.float32)
         expected = np.zeros_like(vis.copy())
         uv_bias = (self.convolve_kernel.data.shape[-1] - 1) // 2 - pixels // 2
         for i in range(n_vis):
@@ -155,9 +155,13 @@ class TestGridder(BaseTest):
             weights_grid_host = weights_grid.empty_like()
             _middle(weights_grid_host, self.weights_grid.shape)[:] = self.weights_grid
             weights_grid.set_async(command_queue, weights_grid_host)
-            fn.num_vis = len(self.uv)
-            fn.set_coordinates(self.uv, self.sub_uv, self.w_plane)
-            fn.set_vis(vis)
+            n_vis = len(self.uv)
+            fn.num_vis = n_vis
+            fn.buffer('uv').set_region(
+                command_queue, np.concatenate((self.uv, self.sub_uv), axis=1),
+                np.s_[:n_vis], np.s_[:])
+            fn.buffer('w_plane').set_region(command_queue, self.w_plane, np.s_[:n_vis], np.s_[:])
+            fn.buffer('vis').set_region(command_queue, vis, np.s_[:n_vis], np.s_[:])
             fn()
             return grid_data.get(command_queue)
         self.do_grid(callback)
@@ -202,9 +206,12 @@ class TestDegridder(BaseTest):
             grid_buffer = fn.buffer('grid')
             grid_buffer.set(command_queue, _middle(grid_data, grid_buffer.shape))
             fn.num_vis = n_vis
-            fn.set_coordinates(self.uv, self.sub_uv, self.w_plane)
-            fn.set_weights(weights)
-            fn.set_vis(vis)
+            fn.buffer('uv').set_region(
+                command_queue, np.concatenate((self.uv, self.sub_uv), axis=1),
+                np.s_[:n_vis], np.s_[:])
+            fn.buffer('w_plane').set_region(command_queue, self.w_plane, np.s_[:n_vis], np.s_[:])
+            fn.buffer('vis').set_region(command_queue, vis, np.s_[:n_vis], np.s_[:])
+            fn.buffer('weights').set_region(command_queue, weights, np.s_[:n_vis], np.s_[:])
             fn()
             return fn.buffer('vis').get(command_queue)[:n_vis]
         self.do_degrid(callback)

--- a/katsdpimager/weight.py
+++ b/katsdpimager/weight.py
@@ -515,20 +515,10 @@ class Weights(accel.OperationSequence):
         if self._fill is None:
             self.buffer('grid').zero(self.command_queue)
 
-    def grid(self, uv, weights):
+    def grid(self, N):
         self.ensure_all_bound()
         if self._grid_weights is not None:
-            N = len(uv)
             self._grid_weights.num_vis = N
-            # TODO: share these buffers with grid/predict
-            self._host_uv[:N] = uv
-            self._host_weights[:N] = weights
-            self.buffer('uv').set_region(
-                self.command_queue, self._host_uv,
-                np.s_[:N, 0:2], np.s_[:N, 0:2], blocking=False)
-            self.buffer('weights').set_region(
-                self.command_queue, self._host_weights,
-                np.s_[:N], np.s_[:N], blocking=False)
             return self._grid_weights()
 
     def finalize(self):

--- a/katsdpimager/weight.py
+++ b/katsdpimager/weight.py
@@ -279,8 +279,6 @@ class DensityWeights(accel.Operation):
                              accel.roundup(grid.shape[1], self.template.wgs_y)),
                 local_size=(self.template.wgs_x, self.template.wgs_y)
             )
-        if isinstance(sums, accel.SVMArray):
-            self.command_queue.finish()
         sums.get(self.command_queue, self._sums_host)
         rms = np.sqrt(self._sums_host[2]) / self._sums_host[1]
         return rms, rms * np.sqrt(self._sums_host[0])
@@ -374,8 +372,6 @@ class MeanWeight(accel.Operation):
                              accel.roundup(grid.shape[1], self.template.wgs_y)),
                 local_size=(self.template.wgs_x, self.template.wgs_y)
             )
-        if isinstance(sums, accel.SVMArray):
-            self.command_queue.finish()
         sums.get(self.command_queue, self._sums_host)
         return self._sums_host[1] / self._sums_host[0]
 


### PR DESCRIPTION
SVM aka Unified Memory presents an apparent shared mapping of memory between GPU and CPU, but it's implemented on desktop cards with page faulting (on Tegra it is really shared, which is why the imager original used it). While simpler to use, I found it became difficult to reason about synchronisation, difficult to implement overlap of GPU and CPU work, and caused unnecessary transfer traffic.

Replace it all with standard memory where the program explicitly enqueues transfers. Because the transfers are submitted through the command queue, they're naturally sequenced with GPU work (which allows a lot of calls to `queue.finish()` to be removed), and one just needs to be careful about CPU-side synchronisation when using asynchronous transfers (which is handled by the `_HostBuffer` class).

This allows some overlap between CPU work and GPU compute (e.g. loading visibility data while gridding previous visibility data). There is currently no overlap between GPU transfers and GPU compute, but the transfers account for a very small fraction of time so there is probably not much benefit in it.