### PR TITLE
Disable profile collection for imager-mkat-pipeline.py 

### DIFF
--- a/katsdpimager/profiling.py
+++ b/katsdpimager/profiling.py
@@ -410,6 +410,11 @@ class NullProfiler(Profiler):
                 labels: Mapping[str, Any] = {}) -> Generator[Stopwatch, None, None]:
         yield NullStopwatch(self, Frame(name, {}))
 
+    @contextlib.contextmanager
+    def profile_device(self, queue: katsdpsigproc.abc.AbstractCommandQueue,
+                       name: str, labels: Mapping[str, Any] = {}):
+        yield
+
 
 @contextlib.contextmanager
 def profile_device(queue: katsdpsigproc.abc.AbstractCommandQueue,

--- a/scripts/imager-mkat-pipeline.py
+++ b/scripts/imager-mkat-pipeline.py
@@ -244,6 +244,10 @@ def main():
     if args.log_level is not None:
         logger.setLevel(args.log_level.upper())
 
+    # Use the NullProfiler (i.e. disable profiling) because the real one
+    # uses excessive memory. TODO: re-enable once the profiler is optimised.
+    profiling.Profiler.set_profiler(profiling.NullProfiler())
+
     with closing(loader.load(args.input_file, args.input_option,
                              args.start_channel, args.stop_channel)) as dataset:
         writer = Writer(args, dataset)


### PR DESCRIPTION
It uses excessive memory. This is a quick fix for SPR1-919, but a proper
fix would be to accumulate flamegraph data on the fly.