### PR TITLE
Rewrite of profiling collection and reporting

### DIFF
--- a/scripts/imager-mkat-pipeline.py
+++ b/scripts/imager-mkat-pipeline.py
@@ -244,9 +244,7 @@ def main():
     if args.log_level is not None:
         logger.setLevel(args.log_level.upper())
 
-    # Use the NullProfiler (i.e. disable profiling) because the real one
-    # uses excessive memory. TODO: re-enable once the profiler is optimised.
-    profiling.Profiler.set_profiler(profiling.NullProfiler())
+    profiling.Profiler.set_profiler(profiling.FlamegraphProfiler())
 
     with closing(loader.load(args.input_file, args.input_option,
                              args.start_channel, args.stop_channel)) as dataset:

--- a/scripts/imager.py
+++ b/scripts/imager.py
@@ -149,8 +149,8 @@ def main():
         if '%' not in args.output_file:
             parser.error('More than one channel selected but no %d in output filename')
     configure_logging(args)
-    if not args.write_profile and not args.write_device_profile:
-        profiling.Profiler.set_profiler(profiling.NullProfiler())
+    if args.write_profile or args.write_device_profile:
+        profiling.Profiler.set_profiler(profiling.FlamegraphProfiler())
 
     queue = None
     context = None
@@ -165,12 +165,15 @@ def main():
                              args.start_channel, args.stop_channel)) as dataset:
         frontend.run(args, context, queue, dataset, Writer(args, dataset))
 
+    profiler = profiling.Profiler.get_profiler()
     if args.write_profile:
         with open(args.write_profile, 'w') as f:
-            profiling.Profiler.get_profiler().write_flamegraph(f)
+            assert isinstance(profiler, profiling.FlamegraphProfiler)
+            profiler.write_flamegraph(f)
     if args.write_device_profile:
         with open(args.write_device_profile, 'w') as f:
-            profiling.Profiler.get_profiler().write_device_flamegraph(f)
+            assert isinstance(profiler, profiling.FlamegraphProfiler)
+            profiler.write_device_flamegraph(f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reenables profile collection without the issues caused in
SPR1-919.

- The default Profiler is now changed to NullProfiler, so that only code
  that explicitly opts in to profiling will get it.
- Profiler is now an abstract base class, with record handling
  implemented add_record / add_device_record provided by the subclass.
- The original functionality has been split into two classes:
  1. CollectProfiler collects complete records. It's used for unit
     testing.
  2. FlamegraphProfiler aggregates statistics as they're received, to
     keep memory usage bounded independent of the number of channels
     processed. To avoid blocking on the device, DeviceRecords are put
     in a queue for aging so that by the time we want to know the
     runtime the work should generally have completed. The queue size
     is bounded to control memory usage.

The unit tests are also beefed up to explicitly test the flamegraph
writing. Some extra decorators have been used to reduce the amount of
boilerplate.