### PR TITLE
Rewrite primary_beam module in terms of katsdpmodels.primary_beam

### DIFF
--- a/katsdpimager/parameters.py
+++ b/katsdpimager/parameters.py
@@ -222,8 +222,8 @@ class FixedGridParameters:
         Number of UV cells corresponding to the combined W+antialias kernel.
     degrid : bool, optional
         If true, use degridding, otherwise use direct prediction.
-    beams : :class:`primary_beam.BeamModelSet`, optional
-        Primary beam models for correction.
+    beams : :class:`katsdpmodels.primary_beam.PrimaryBeam`, optional
+        Primary beam model for correction.
     """
     def __init__(self, antialias_width, oversample, image_oversample,
                  max_w, kernel_width, degrid=False, beams=None):


### PR DESCRIPTION
This module pre-dated katsdpmodels.primary_beam and tried to present a
very general interface, but a different one to katsdpmodels. In future
katsdpmodels will be used for the primary beam models, and the
TrivialPrimaryBeam will be for backwards compatibility. It's thus
convenient for it to implement the common PrimaryBeam interface.

In theory it would now be possible to support any circularly-symmetric
PrimaryBeam, but since TrivialPrimaryBeam is the only such interface,
there is no point trying to accept arbitrary PrimaryBeam models until
there is support for models that rotate over time.

See SPR1-855.