### PR TITLE
Update .pre-commit-config.yaml to use same flake8 as Jenkins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
+repos:
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+  rev: 3.9.2
   hooks:
     - id: flake8

--- a/tests/images_report.py
+++ b/tests/images_report.py
@@ -16,12 +16,12 @@ import io
 import glob
 from contextlib import closing
 
-from mako.template import Template
-import matplotlib
-matplotlib.use('Agg')   # noqa: E402
-import aplpy
 from astropy.io import fits
 from astropy.wcs import WCS
+from mako.template import Template
+import matplotlib
+matplotlib.use('Agg')
+import aplpy     # noqa: E402
 
 
 MODE_CLEAN = 'Clean'


### PR DESCRIPTION
This triggered some additional flake8 warnings about imports not at the
top of the file (necessary because matplotlib needs to be configured
immediately after import, before modules that use matplot (in this case,
aplpy) are imported.