### PR TITLE
Stop sending test image report to bmerry

### DIFF
--- a/Jenkinsfile.report
+++ b/Jenkinsfile.report
@@ -47,4 +47,4 @@ catchError {
         }
     }
 }
-katsdp.mail('bmerry@ska.ac.za')
+katsdp.mail('sdpdev+katsdpimager@ska.ac.za')


### PR DESCRIPTION
Send it to the mail alias used by the main Jenkinsfile instead.